### PR TITLE
Check for empty string in `h`

### DIFF
--- a/h.js
+++ b/h.js
@@ -26,7 +26,7 @@ function h(tagName, properties, children) {
     tag = parseTag(tagName, props)
 
 
-    if (children) {
+    if (children || children === '') {
         if (isArray(children)) {
             for (var i =0; i < children.length; i++) {
                 addChild(children[i], childNodes)


### PR DESCRIPTION
This allows for empty text nodes to be created

``` js
var elem = h('div', '')
```

and it creates an empty text node instead of no children
