### PR TITLE
Dedupe version numbers

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,4 +1,3 @@
-var pj = require("./package.json")
 var semver = require("semver")
 
-module.exports = semver.clean(pj.version)
+module.exports = semver.clean("0.1.0")


### PR DESCRIPTION
Requiring package.json is not good enough

Including the package.json in the bundle is bad because npm puts the entire README in the bundle. fileSize muchos large :(
