### PR TITLE
Update data-set version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "browser-split": "0.0.1",
     "extend": "~1.2.1",
-    "data-set": "~0.2.2",
+    "data-set": "^2.0.1",
     "semver": "~2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The new version of data-set never uses the native implementation.

This means that `h('div', { 'data-foo': { 'bar': 'baz' } })` will do what you what expect all the time.

previously the browser implementations would cast `{ 'bar': 'baz' }` to `'[object Object]'` which was very suprising.
