### PR TITLE
remove data-set dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "browser-split": "0.0.1",
     "extend": "~1.2.1",
-    "data-set": "~3.0.0",
     "semver": "~2.2.1",
     "cuid": "^1.2.1"
   },

--- a/render.js
+++ b/render.js
@@ -1,4 +1,3 @@
-var DataSet = require("data-set")
 var globalDocument = require("./lib/document")
 
 var isVirtualDomNode = require("./lib/is-virtual-dom")
@@ -52,8 +51,6 @@ function applyProperties(node, props) {
                     node.style[s] = propValue[s]
                 }
             }
-        } else if (propName.substr(0, 5) === "data-") {
-            DataSet(node)[propName.substr(5)] = propValue
         } else {
             node[propName] = propValue
         }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 var test = require("tape")
-var DataSet = require("data-set")
 
 var h = require("../h")
 var diff = require("../diff")
@@ -231,18 +230,6 @@ test("mixture of node/classname applied correctly", function (assert) {
     assert.equal(dom.className, "very pretty")
     assert.equal(dom.tagName, "div")
     assert.equal(dom.childNodes.length, 0)
-    assert.end()
-})
-
-test("data-set is applied correctly", function (assert) {
-    var vdom = h("div", { "data-id": "12345" })
-    var dom = render(vdom)
-    var data = DataSet(dom)
-    assert.false(dom.id)
-    assert.false(dom.className)
-    assert.equal(dom.tagName, "div")
-    assert.equal(dom.childNodes.length, 0)
-    assert.equal(data.id, "12345")
     assert.end()
 })
 


### PR DESCRIPTION
i'm wondering if you're interested in removing this to reduce the dependencies.  this can be achieved using a higher order function and leveraging a property value that is a function.

``` js
function dataset(value) {
  return function (node, propName) {
    require('data-set')(node)[propName] = value;
  };
}

h('div', {
   prop: dataset('value')
});
```
