### PR TITLE
respect undefined

### DIFF
--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -21,7 +21,7 @@ function applyProperties(node, props, previous) {
                 for (var k in propValue) {
                     node[propName][k] = propValue[k]
                 }
-            } else {
+            } else if (propValue !== undefined) {
                 node[propName] = propValue
             }
         }


### PR DESCRIPTION
When you call `createElement(vtree)` where `vtree` has a property whose value is `undefined` then `applyProperties` will set the value to undefined.

Example:

``` js
h("input", {
  value: state.isReset ?
    resetHook("", state.events.reset) :
    undefined
})
```

Having `applyProperties` gaurd against this means that free variables are respected
