### PR TITLE
hooks should run after properties have been applied

### DIFF
--- a/test/hook.js
+++ b/test/hook.js
@@ -44,7 +44,7 @@ test("Node child hooks are identified", function (assert) {
 
 test("hooks get called in render", function (assert) {
     var counter = 0
-    var vtree = h("div", {
+    var vtree = h("div.foo", {
         "some-key": hook(function (elem, prop) {
             counter++
             assert.equal(prop, "some-key")


### PR DESCRIPTION
i think hooks should run after all other ops.  in this example, the hook is
applied before the className property is set from parsing the tag.

i found this while working on a PR for #74
