### PR TITLE
Added npm scripts for releasing new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "tap-dot": "^0.2.1",
     "tap-spec": "^0.2.0",
     "tape": "^2.13.4",
-    "zuul": "^1.10.0"
+    "zuul": "^1.10.0",
+    "semver": "^4.1.0",
+    "execSync": "^1.0.2"
   },
   "licenses": [
     {
@@ -51,7 +53,11 @@
     "browser": "run-browser test/index.js",
     "phantom": "run-browser test/index.js -b | tap-spec",
     "dist": "browserify --standalone virtual-dom index.js > dist/virtual-dom.js",
-    "travis-test": "npm run phantom && npm run cover && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)"
+    "travis-test": "npm run phantom && npm run cover && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
+    "release": "npm run release-patch",
+    "release-patch": "node ./scripts/release.js patch",
+    "release-minor": "node ./scripts/release.js minor",
+    "release-major": "node ./scripts/release.js major"
   },
   "testling": {
     "files": "test/*.js",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,21 @@
+'use strict';
+var fs = require('fs');
+var semver = require('semver');
+var execSync = require('execSync');
+
+var packageFilename = '../package.json';
+
+function release(type) {
+  execSync.run('git checkout master');
+  var pkg = require(packageFilename);
+  pkg.version = semver.inc(pkg.version, type);
+  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+  execSync.run('git commit -a -m "Bumped version to v' + pkg.version + '"');
+  execSync.run('git push origin master');
+  execSync.run('git tag v' + pkg.version);
+  execSync.run('git push origin --tags');
+  execSync.run('npm publish');
+}
+
+release(process.argv[2] || 'patch');
+


### PR DESCRIPTION
Related to issue #131 

This will allow you to release a new version by just calling `npm run release` (which defaults to `npm run release-patch`, you can also call `npm run release-minor` or `npm run release-major`). It updates package.json version, commits and pushes to master, makes the git tag, and publishes in npm. Should help for never forgetting to do all those steps when releasing. I use this script in Cycle too.

I guess you probably won't like the new "scripts" directory, but you can choose where and how to organize it. Anyway this whole PR is just a suggestion.
