### PR TITLE
passing children as arguments

### DIFF
--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -83,7 +83,7 @@ function h(tagName, properties, children) {
 
     if (children !== undefined && children !== null) {
         addChild(children, childNodes, tag, props)
-        for (var i = 0,
+        if (arguments.length > 3) for (var i = 0,
             args = [].slice.call(arguments, 3);
                 i < args.length; i++) {
             addChild(args[i], childNodes, tag, props)


### PR DESCRIPTION
coming from hyperscript original I was sad to see varargs not passed as children. if you'd like to add it, it's a few lines..

cool project dude
