### PR TITLE
refactor to enum/constants for node types

### DIFF
--- a/test/keys.js
+++ b/test/keys.js
@@ -7,6 +7,7 @@ var render = require("../create-element.js")
 
 var patchCount = require("./lib/patch-count.js")
 var assertEqualDom = require("./lib/assert-equal-dom.js")
+var nodeType = require("../vnode/vnodetype")
 
 test("keys get reordered", function (assert) {
     var leftNode = h("div", [
@@ -195,7 +196,7 @@ test("widgets can be keyed", function (assert) {
         }
     }
 
-    DivWidget.prototype.type = "Widget"
+    DivWidget.prototype.type = nodeType.Widget
 
     var leftNode = h("div", [
         new DivWidget("1", "a"),
@@ -387,7 +388,7 @@ test("adding multiple widgets", function (assert) {
         elem.textContent = this.foo + this.counter
     }
 
-    FooWidget.prototype.type = "Widget"
+    FooWidget.prototype.type = nodeType.Widget
 
     var firstTree = h("div", [])
     var rootNode = render(firstTree)

--- a/test/main.js
+++ b/test/main.js
@@ -7,6 +7,7 @@ var render = require("../create-element.js")
 var Node = require("../vnode/vnode")
 var TextNode = require("../vnode/vtext")
 var version = require("../vnode/version")
+var nodeType = require("../vnode/vnodetype")
 var assertEqualDom = require("./lib/assert-equal-dom.js")
 var patchCount = require("./lib/patch-count.js")
 
@@ -19,7 +20,7 @@ test("Node is a function", function (assert) {
 })
 
 test("Node type and version are set", function (assert) {
-    assert.equal(Node.prototype.type, "VirtualNode")
+    assert.equal(Node.prototype.type, nodeType.VirtualNode)
     assert.deepEqual(Node.prototype.version, version)
     assert.end()
 })
@@ -30,7 +31,7 @@ test("TextNode is a function", function (assert) {
 })
 
 test("TextNode type and version are set", function (assert) {
-    assert.equal(TextNode.prototype.type, "VirtualText")
+    assert.equal(TextNode.prototype.type, nodeType.VirtualText)
     assert.deepEqual(TextNode.prototype.version, version)
     assert.end()
 })
@@ -457,7 +458,7 @@ test("Widget is initialised on render", function (assert) {
         update: function () {
             initCount = 1000000
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var result = render(Widget)
@@ -478,7 +479,7 @@ test("Nested widget is initialised on render", function (assert) {
         update: function () {
             initCount = 1000000
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var vdom = h("div", [
@@ -525,7 +526,7 @@ test("Patch widgets at the root", function (assert) {
         return h("div", "" + state.a)
     }
 
-    Widget.prototype.type = "Widget"
+    Widget.prototype.type = nodeType.Widget
 
     var leftTree = new Widget(leftState)
     var rightTree = new Widget(rightState)
@@ -578,7 +579,7 @@ test("Patch nested widgets", function (assert) {
         return h("div", "" + state.a)
     }
 
-    Widget.prototype.type = "Widget"
+    Widget.prototype.type = nodeType.Widget
 
     var leftWidget = new Widget(leftState)
     var rightWidget = new Widget(rightState)
@@ -644,7 +645,7 @@ test("Ensure children are not rendered more than once", function (assert) {
         return h("div", "" + state.a)
     }
 
-    Widget.prototype.type = "Widget"
+    Widget.prototype.type = nodeType.Widget
 
     var rightWidget = new Widget(rightState)
 
@@ -681,13 +682,13 @@ test("VNode indicates stateful sibling", function (assert) {
         init: function () {},
         update: function () {},
         destroy: function () {},
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var pureWidget = {
         init: function () {},
         update: function () {},
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var stateful = h("div", [statefulWidget])
@@ -706,7 +707,7 @@ test("Replacing stateful widget with vnode calls destroy", function (assert) {
         destroy: function () {
             count++
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var rootNode = render(h("div"))
@@ -723,7 +724,7 @@ test("Replacing stateful widget with stateful widget", function (assert) {
         destroy: function () {
             count++
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var newWidget = {
@@ -732,7 +733,7 @@ test("Replacing stateful widget with stateful widget", function (assert) {
         destroy: function () {
             count = 10000000
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var rootNode = render(h("div"))
@@ -750,13 +751,13 @@ test("Replacing stateful widget with pure widget", function (assert) {
         destroy: function () {
             count++
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var newWidget = {
         init: function () {},
         update: function () {},
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var rootNode = render(h("div"))
@@ -773,7 +774,7 @@ test("Removing stateful widget calls destroy", function (assert) {
         destroy: function () {
             count++
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var rootNode = render(h("div"))
@@ -796,7 +797,7 @@ test("Patching parent destroys stateful sibling", function (assert) {
             assert.equal(domNode, widgetRoot)
             count++
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
 
     var deepTree = h("div", [
@@ -839,7 +840,7 @@ test("Widget update can replace domNode", function (assert) {
         return widgetUpdate
     }
     Widget.prototype.destroy = function () {}
-    Widget.prototype.type = "Widget"
+    Widget.prototype.type = nodeType.Widget
 
     var initTree = h("div.init", [new Widget])
     var updateTree = h("div.update", [new Widget])
@@ -868,7 +869,7 @@ test("Destroy widget nested in removed thunk", function (assert) {
             assert.equal(domNode, widgetRoot)
             count++
         },
-        type: "Widget"
+        type: nodeType.Widget
     }
     var vnode = h(".wrapper", statefulWidget)
 

--- a/vnode/is-thunk.js
+++ b/vnode/is-thunk.js
@@ -1,5 +1,7 @@
+var nodeType = require("./vnodetype")
+
 module.exports = isThunk
 
 function isThunk(t) {
-    return t && t.type === "Thunk"
+    return t && t.type === nodeType.Thunk
 }

--- a/vnode/is-vnode.js
+++ b/vnode/is-vnode.js
@@ -1,7 +1,8 @@
 var version = require("./version")
+var nodeType = require("./vnodetype")
 
 module.exports = isVirtualNode
 
 function isVirtualNode(x) {
-    return x && x.type === "VirtualNode" && x.version === version
+    return x && x.type === nodeType.VirtualNode && x.version === version
 }

--- a/vnode/is-vtext.js
+++ b/vnode/is-vtext.js
@@ -1,7 +1,8 @@
 var version = require("./version")
+var nodeType = require("./vnodetype")
 
 module.exports = isVirtualText
 
 function isVirtualText(x) {
-    return x && x.type === "VirtualText" && x.version === version
+    return x && x.type === nodeType.VirtualText && x.version === version
 }

--- a/vnode/is-widget.js
+++ b/vnode/is-widget.js
@@ -1,5 +1,7 @@
+var nodeType = require("./vnodetype")
+
 module.exports = isWidget
 
 function isWidget(w) {
-    return w && w.type === "Widget"
+    return w && w.type === nodeType.Widget
 }

--- a/vnode/test/handle-thunk.js
+++ b/vnode/test/handle-thunk.js
@@ -1,5 +1,6 @@
 var test = require("tape")
 
+var nodeType = require("../vnodetype")
 var handleThunk = require("../handle-thunk")
 var VNode = require("../vnode")
 var VText = require("../vtext")
@@ -9,7 +10,7 @@ test("render a new thunk to vnode", function (assert) {
         render: function (previous) {
             assert.error("Render should not be called for cached thunk")
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     aNode.vnode = new VNode("div")
@@ -21,7 +22,7 @@ test("render a new thunk to vnode", function (assert) {
             assert.equal(previous, aNode)
             return renderedBNode
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     var result = handleThunk(aNode, bNode)
@@ -37,7 +38,7 @@ test("render a new thunk to vtext", function (assert) {
         render: function (previous) {
             assert.error("Render should not be called for cached thunk")
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     aNode.vnode = new VNode("div")
@@ -49,7 +50,7 @@ test("render a new thunk to vtext", function (assert) {
             assert.equal(previous, aNode)
             return renderedBNode
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     var result = handleThunk(aNode, bNode)
@@ -65,19 +66,19 @@ test("render a new thunk to a widget", function (assert) {
         render: function (previous) {
             assert.error("Render should not be called for cached thunk")
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     aNode.vnode = new VNode("div")
 
-    var renderedBNode = { type: "Widget" }
+    var renderedBNode = { type: nodeType.Widget }
 
     var bNode = {
         render: function (previous) {
             assert.equal(previous, aNode)
             return renderedBNode
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     var result = handleThunk(aNode, bNode)
@@ -93,7 +94,7 @@ test("render current thunk to a thunk throws exception", function (assert) {
         render: function (previous) {
             assert.error("Render should not be called for cached thunk")
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     aNode.vnode = new VNode("div")
@@ -101,9 +102,9 @@ test("render current thunk to a thunk throws exception", function (assert) {
     var bNode = {
         render: function (previous) {
             assert.equal(previous, aNode)
-            return { type: "Thunk" }
+            return { type: nodeType.Thunk }
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     var result
@@ -122,9 +123,9 @@ test("render previous thunk to a thunk throws exception", function (assert) {
     var aNode = {
         render: function (previous) {
             assert.equal(previous, null)
-            return { type: "Thunk" }
+            return { type: nodeType.Thunk }
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     var renderedBNode = new VNode("div")
@@ -134,7 +135,7 @@ test("render previous thunk to a thunk throws exception", function (assert) {
             assert.equal(previous, aNode)
             return renderedBNode
         },
-        type: "Thunk"
+        type: nodeType.Thunk
     }
 
     var result

--- a/vnode/vnode.js
+++ b/vnode/vnode.js
@@ -1,4 +1,5 @@
 var version = require("./version")
+var nodeType = require("./vnodetype")
 var isVNode = require("./is-vnode")
 var isWidget = require("./is-widget")
 var isThunk = require("./is-thunk")
@@ -69,4 +70,4 @@ function VirtualNode(tagName, properties, children, key, namespace) {
 }
 
 VirtualNode.prototype.version = version
-VirtualNode.prototype.type = "VirtualNode"
+VirtualNode.prototype.type = nodeType.VirtualNode

--- a/vnode/vnodetype.js
+++ b/vnode/vnodetype.js
@@ -1,0 +1,9 @@
+VirtualNodeType.Thunk = "Thunk"
+VirtualNodeType.VirtualNode = "VirtualNode"
+VirtualNodeType.VirtualPatch = "VirtualPatch"
+VirtualNodeType.VirtualText = "VirtualText"
+VirtualNodeType.Widget = "Widget"
+
+module.exports = VirtualNodeType
+
+function VirtualNodeType() {}

--- a/vnode/vpatch.js
+++ b/vnode/vpatch.js
@@ -1,4 +1,5 @@
 var version = require("./version")
+var nodeType = require("./vnodetype")
 
 VirtualPatch.NONE = 0
 VirtualPatch.VTEXT = 1
@@ -19,4 +20,4 @@ function VirtualPatch(type, vNode, patch) {
 }
 
 VirtualPatch.prototype.version = version
-VirtualPatch.prototype.type = "VirtualPatch"
+VirtualPatch.prototype.type = nodeType.VirtualPatch

--- a/vnode/vtext.js
+++ b/vnode/vtext.js
@@ -1,4 +1,5 @@
 var version = require("./version")
+var nodeType = require("./vnodetype")
 
 module.exports = VirtualText
 
@@ -7,4 +8,4 @@ function VirtualText(text) {
 }
 
 VirtualText.prototype.version = version
-VirtualText.prototype.type = "VirtualText"
+VirtualText.prototype.type = nodeType.VirtualText


### PR DESCRIPTION
Replace string references to centralised VirtualNodeType class references. This helps when making changes to
names and types and not repeating string literals in test cases etc.

Tests are passing on this branch
