### PR TITLE
fix replace stateful widget with vnode

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -895,6 +895,35 @@ test("Destroy widget nested in removed thunk", function (assert) {
     assert.end()
 })
 
+test("Can replace stateful widget with vnode", function (assert) {
+    var statefulWidget  = {
+        init: function () {
+            return render(h("div.widget"))
+        },
+        update: function () {},
+        destroy: function () {},
+        type: "Widget"
+    }
+
+    var leftNode = h("div", statefulWidget)
+    var rightNode = h("div", h("div.vnode"))
+
+    var rootNode = render(leftNode)
+
+    assert.equal(rootNode.childNodes.length, 1)
+    assert.equal(rootNode.childNodes[0].className, 'widget')
+
+    var patches = diff(leftNode, rightNode)
+    var newRoot = patch(rootNode, patches)
+
+    assert.equal(newRoot, rootNode)
+
+    assert.equal(newRoot.childNodes.length, 1)
+    assert.equal(newRoot.childNodes[0].className, 'vnode')
+
+    assert.end()
+})
+
 test("Create element respects namespace", function (assert) {
     if (!supportsNamespace()) {
         assert.skip("browser doesn't support namespaces");

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -33,6 +33,8 @@ function applyPatch(vpatch, domNode, renderOptions) {
         case VPatch.THUNK:
             return replaceRoot(domNode,
                 renderOptions.patch(domNode, patch, renderOptions))
+        case VPatch.DESTROY:
+            return destroyWidget(domNode, vNode)
         default:
             return domNode
     }

--- a/vnode/vpatch.js
+++ b/vnode/vpatch.js
@@ -9,6 +9,7 @@ VirtualPatch.ORDER = 5
 VirtualPatch.INSERT = 6
 VirtualPatch.REMOVE = 7
 VirtualPatch.THUNK = 8
+VirtualPatch.DESTROY = 9
 
 module.exports = VirtualPatch
 

--- a/vtree/diff.js
+++ b/vtree/diff.js
@@ -183,7 +183,7 @@ function destroyWidgets(vNode, patch, index) {
         if (typeof vNode.destroy === "function") {
             patch[index] = appendPatch(
                 patch[index],
-                new VPatch(VPatch.REMOVE, vNode, null)
+                new VPatch(VPatch.DESTROY, vNode, null)
             )
         }
     } else if (isVNode(vNode) && (vNode.hasWidgets || vNode.hasThunks)) {


### PR DESCRIPTION
The following test fails:

``` js
test("Can replace stateful widget with vnode", function (assert) {
    var statefulWidget  = {
        init: function () {
            return render(h("div.widget"))
        },
        update: function () {},
        destroy: function () {},
        type: "Widget"
    }

    var leftNode = h("div", statefulWidget)
    var rightNode = h("div", h("div.vnode"))

    var rootNode = render(leftNode)

    assert.equal(rootNode.childNodes.length, 1)
    assert.equal(rootNode.childNodes[0].className, 'widget')

    var patches = diff(leftNode, rightNode)
    var newRoot = patch(rootNode, patches)

    assert.equal(newRoot, rootNode)

    assert.equal(newRoot.childNodes.length, 1)
    assert.equal(newRoot.childNodes[0].className, 'vnode')

    assert.end()
})
```

I've managed to fix by adding a new kind of patch: `VPatch.DESTROY`

All tests pass, hopefully good to go. As long as my approach seems ok :)
