### PR TITLE
fix replace VNode with VText

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -444,6 +444,27 @@ test("Allow empty textnode", function (assert) {
     assert.end()
 })
 
+test("Can replace vnode with vtext", function (assert) {
+
+    var leftNode = h("div", h("div"))
+    var rightNode = h("div", "text")
+
+    var rootNode = render(leftNode)
+
+    assert.equal(rootNode.childNodes.length, 1)
+    assert.equal(rootNode.childNodes[0].nodeType, 1)
+
+    var patches = diff(leftNode, rightNode)
+
+    var newRoot = patch(rootNode, patches)
+
+    assert.equal(newRoot, rootNode)
+
+    assert.equal(newRoot.childNodes.length, 1)
+    assert.equal(newRoot.childNodes[0].nodeType, 3)
+
+    assert.end()
+})
 
 // Widget tests
 test("Widget is initialised on render", function (assert) {

--- a/vtree/diff.js
+++ b/vtree/diff.js
@@ -59,6 +59,7 @@ function walk(a, b, patch, index) {
         }
     } else if (isVText(b)) {
         if (!isVText(a)) {
+            apply = appendPatch(apply, new VPatch(VPatch.VTEXT, a, b))
             applyClear = true
         } else if (a.text !== b.text) {
             apply = appendPatch(apply, new VPatch(VPatch.VTEXT, a, b))


### PR DESCRIPTION
87b9ad36fd72548bf60f62eaa0db130fd6f869d5 broke the following test:

``` js
test("Can replace vnode with vtext", function (assert) {

    var leftNode = h("div", h("div"))
    var rightNode = h("div", "text")

    var rootNode = render(leftNode)

    assert.equal(rootNode.childNodes.length, 1)
    assert.equal(rootNode.childNodes[0].nodeType, 1)

    var patches = diff(leftNode, rightNode)

    var newRoot = patch(rootNode, patches)

    assert.equal(newRoot, rootNode)

    assert.equal(newRoot.childNodes.length, 1)
    assert.equal(newRoot.childNodes[0].nodeType, 3)

    assert.end()
})
```

Was caused by missing `apply = appendPatch(apply, new VPatch(VPatch.VTEXT, a, b))` on VText patch handler

This PR puts it back!
