### PR TITLE
removes verticalAlign style from first example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ function render(count)  {
     return h('div', {
         style: {
             textAlign: 'center',
-            verticalAlign: 'center',
             lineHeight: (100 + count) + 'px',
             border: '1px solid red',
             width: (100 + count) + 'px',


### PR DESCRIPTION
very small change, vertical-align attribute only applies to elements with a display type of `inline` or `table`
