### PR TITLE
optimize the case where a new element is added to front of list

### DIFF
--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -154,9 +154,8 @@ function reorderChildren(domNode, bIndex) {
             insertNode = childNodes[i + insertOffset] || null
             insertedLength = 0
             while (node !== insertNode && insertedLength++ < chainLength) {
-                nextSibling = node.nextSibling;
                 domNode.insertBefore(node, insertNode);
-                node = nextSibling;
+                node = children[move + insertedLength];
             }
 
             // the moved element came from the front of the array so reduce the insert offset

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -133,22 +133,34 @@ function reorderChildren(domNode, bIndex) {
     var move
     var node
     var insertNode
-    for (i = 0; i < len; i++) {
+    var chainLength
+    var insertedLength
+    var nextSibling
+    for (i = 0; i < len;) {
         move = bIndex[i]
+        chainLength = 1
         if (move !== undefined && move !== i) {
+            // try to bring forward as long of a chain as possible
+            while (bIndex[i + chainLength] === move + chainLength) {
+                chainLength++;
+            }
+
             // the element currently at this index will be moved later so increase the insert offset
-            if (reverseIndex[i] > i + 1) {
+            if (reverseIndex[i] > i + chainLength) {
                 insertOffset++
             }
 
             node = children[move]
             insertNode = childNodes[i + insertOffset] || null
-            if (node !== insertNode) {
-                domNode.insertBefore(node, insertNode)
+            insertedLength = 0
+            while (node !== insertNode && insertedLength++ < chainLength) {
+                nextSibling = node.nextSibling;
+                domNode.insertBefore(node, insertNode);
+                node = nextSibling;
             }
 
             // the moved element came from the front of the array so reduce the insert offset
-            if (move < i - 1) {
+            if (move + chainLength < i) {
                 insertOffset--
             }
         }
@@ -157,6 +169,8 @@ function reorderChildren(domNode, bIndex) {
         if (i in bIndex.removes) {
             insertOffset++
         }
+
+        i += chainLength
     }
 }
 

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -137,7 +137,7 @@ function reorderChildren(domNode, bIndex) {
         move = bIndex[i]
         if (move !== undefined && move !== i) {
             // the element currently at this index will be moved later so increase the insert offset
-            if (reverseIndex[i] > i) {
+            if (reverseIndex[i] > i + 1) {
                 insertOffset++
             }
 
@@ -148,7 +148,7 @@ function reorderChildren(domNode, bIndex) {
             }
 
             // the moved element came from the front of the array so reduce the insert offset
-            if (move < i) {
+            if (move < i - 1) {
                 insertOffset--
             }
         }


### PR DESCRIPTION
@AlexGalays this PR provides an optimization for the specific case you mentioned in https://github.com/Matt-Esch/virtual-dom/issues/104#issuecomment-68447534

the patches will still look the same but i've optimized `reorderChildren` to better deal with node reordering.  previously the algorithm only recognized when the node at the current insert point was going to move towards the end of the list of children and inserted after it but now i've changed it to realize when inserting a node before the current insert point will put that node in the right place and hence reduce the number of moves needed.

in your case it was previously doing these 2 patches:
  1. add the `'3'` node to the end of the list of children
  1. reorder the children
    * the `'3'` node needs to move to position 0
    * the element at position 0 (the current insert position) is scheduled to move towards the end of the list of children so increase our insertion offset and insert `'3'` after this node and then when the node at 0 moves, `'3'` will be at position 0
    * move the insert point 
    * the  `'1'` node needs to move to the current insert point
    * the node currently at the insert point is scheduled to move towards the end of the list of children so increase the insertion offset and insert `'1'` after this node
    * move the insert point
    * the `'2'` node needs to move to the current insert point
    * move the `'2'` node to the current insert point

this led to each node needing to be moved to get them into the right position.  now the 2 patches are handled like this:
  1. add the `'3'` node to the end of the list of children
  1. reorder the children
    * the `'3'` node needs to move to position 0
    * the element at position 0 is scheduled to move towards the end of the list but if we insert this node before it, it will be in the right place so insert `'3'` before the current insert point.
    * move the insert point
    * the `'1'` node needs to move to the current insert point
    * the node at the current insert point is already `'1'` so do nothing
    * move the insert point
    * the `'2'` node needs to move to the current insert point
    * the node at the current insert point is already `'2'` so do nothing