### PR TITLE
Don't try to hook unhook-only hooks.

### DIFF
--- a/test/hook.js
+++ b/test/hook.js
@@ -263,6 +263,30 @@ test("property-replacing diff calls unhook", function (assert) {
   assert.end()
 })
 
+test("unhook-only hook is a valid hook", function (assert) {
+    var unhookCalled = false;
+
+    function UnhookHook() {}
+
+    UnhookHook.prototype.unhook = function() {
+        unhookCalled = true
+    }
+
+    var hook = new UnhookHook()
+
+    var firstTree = h('div', {hook: hook})
+    var secondTree = h('div', {})
+
+    var rootNode = create(firstTree)
+
+    assert.notOk(unhookCalled)
+
+    var patches = diff(firstTree, secondTree)
+    rootNode = patch(rootNode, patches)
+
+    assert.ok(unhookCalled)
+    assert.end()
+})
 
 test("all hooks are unhooked", function (assert) {
     var hookCounts = {}

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -11,9 +11,11 @@ function applyProperties(node, props, previous) {
             removeProperty(node, props, previous, propName);
         } else if (isHook(propValue)) {
             removeProperty(node, props, previous, propName)
-            propValue.hook(node,
-                propName,
-                previous ? previous[propName] : undefined)
+            if (propValue.hook) {
+                propValue.hook(node,
+                    propName,
+                    previous ? previous[propName] : undefined)
+            }
         } else {
             if (isObject(propValue)) {
                 patchObject(node, props, previous, propName, propValue);

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -19,7 +19,7 @@ function applyProperties(node, props, previous) {
         } else {
             if (isObject(propValue)) {
                 patchObject(node, props, previous, propName, propValue);
-            } else if (propValue !== undefined) {
+            } else {
                 node[propName] = propValue
             }
         }


### PR DESCRIPTION
`isHook()` returns true for hooks with only the `unhook` method
as of 75e1f61.

Don't call `hook()` on hooks that don't have a `hook` method.