### PR TITLE
Pass next value to the unhook() method and use it to fix a bug in AttributeHook

### DIFF
--- a/test/hook.js
+++ b/test/hook.js
@@ -125,6 +125,46 @@ test("hooks get called in patch", function (assert) {
     assert.end()
 })
 
+test("hooks are called with DOM node, property name, and previous/next value", function (assert) {
+    var hookArgs = [];
+    var unhookArgs = [];
+
+    function Hook() {}
+    Hook.prototype.hook = function() {
+      hookArgs.push([].slice.call(arguments, 0))
+    }
+    Hook.prototype.unhook = function() {
+      unhookArgs.push([].slice.call(arguments, 0))
+    }
+
+    var hook1 = new Hook()
+    var hook2 = new Hook()
+
+    var first = h("div", {hook: hook1})
+    var second = h("div", {hook: hook2})
+    var third = h("div")
+
+    var elem = create(first)
+    assert.equal(hookArgs.length, 1)
+    assert.deepEqual(hookArgs[0], [elem, 'hook', undefined])
+    assert.equal(unhookArgs.length, 0)
+
+    var patches = diff(first, second)
+    elem = patch(elem, patches)
+    assert.equal(hookArgs.length, 2)
+    assert.deepEqual(hookArgs[1], [elem, 'hook', hook1])
+    assert.equal(unhookArgs.length, 1)
+    assert.deepEqual(unhookArgs[0], [elem, 'hook', hook2])
+
+    patches = diff(second, third)
+    elem = patch(elem, patches)
+    assert.equal(hookArgs.length, 2)
+    assert.equal(unhookArgs.length, 2)
+    assert.deepEqual(unhookArgs[1], [elem, 'hook', undefined])
+
+    assert.end()
+})
+
 test("functions are not hooks in render", function (assert) {
     var counter = 0
     var fakeHook = function () {

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -8,9 +8,9 @@ function applyProperties(node, props, previous) {
         var propValue = props[propName]
 
         if (propValue === undefined) {
-            removeProperty(node, props, previous, propName);
+            removeProperty(node, propName, propValue, previous);
         } else if (isHook(propValue)) {
-            removeProperty(node, props, previous, propName)
+            removeProperty(node, propName, propValue, previous)
             if (propValue.hook) {
                 propValue.hook(node,
                     propName,
@@ -26,7 +26,7 @@ function applyProperties(node, props, previous) {
     }
 }
 
-function removeProperty(node, props, previous, propName) {
+function removeProperty(node, propName, propValue, previous) {
     if (previous) {
         var previousValue = previous[propName]
 
@@ -45,7 +45,7 @@ function removeProperty(node, props, previous, propName) {
                 node[propName] = null
             }
         } else if (previousValue.unhook) {
-            previousValue.unhook(node, propName)
+            previousValue.unhook(node, propName, propValue)
         }
     }
 }

--- a/virtual-hyperscript/hooks/attribute-hook.js
+++ b/virtual-hyperscript/hooks/attribute-hook.js
@@ -19,8 +19,12 @@ AttributeHook.prototype.hook = function (node, prop, prev) {
     node.setAttributeNS(this.namespace, prop, this.value);
 };
 
-AttributeHook.prototype.unhook = function (node, prop) {
-    var colonPosition = prop.indexOf(':')
-    var localName = colonPosition > -1 ? prop.substr(colonPosition + 1) : prop
+AttributeHook.prototype.unhook = function (node, prop, next) {
+    if (next !== undefined) {
+        return;
+    }
+
+    var colonPosition = prop.indexOf(':');
+    var localName = colonPosition > -1 ? prop.substr(colonPosition + 1) : prop;
     node.removeAttributeNS(this.namespace, localName);
 };

--- a/virtual-hyperscript/hooks/attribute-hook.js
+++ b/virtual-hyperscript/hooks/attribute-hook.js
@@ -12,7 +12,9 @@ function AttributeHook(namespace, value) {
 }
 
 AttributeHook.prototype.hook = function (node, prop, prev) {
-    if (prev && prev.value === this.value) {
+    if (prev && prev.type === 'AttributeHook' &&
+        prev.value === this.value &&
+        prev.namespace === this.namespace) {
         return;
     }
 
@@ -20,7 +22,8 @@ AttributeHook.prototype.hook = function (node, prop, prev) {
 };
 
 AttributeHook.prototype.unhook = function (node, prop, next) {
-    if (next !== undefined) {
+    if (next && next.type === 'AttributeHook' &&
+        next.namespace === this.namespace) {
         return;
     }
 
@@ -28,3 +31,5 @@ AttributeHook.prototype.unhook = function (node, prop, next) {
     var localName = colonPosition > -1 ? prop.substr(colonPosition + 1) : prop;
     node.removeAttributeNS(this.namespace, localName);
 };
+
+AttributeHook.prototype.type = 'AttributeHook';

--- a/virtual-hyperscript/test/attribute-hook.js
+++ b/virtual-hyperscript/test/attribute-hook.js
@@ -10,20 +10,29 @@ var diff = require("../../vtree/diff")
 test("sets and removes namespaced attribute", function (assert) {
     var namespace = 'http://ns.com/my'
 
-    var left = h('div', {
-        'myns:myattr': attributeHook(namespace, 'the value')
-    })
+    var hook1 = attributeHook(namespace, 'first value')
+    var hook2 = attributeHook(namespace, 'first value')
+    var hook3 = attributeHook(namespace, 'second value')
 
-    var right = h('div', {})
+    var first = h('div', {'myns:myattr': hook1})
+    var second = h('div', {'myns:myattr': hook2})
+    var third = h('div', {'myns:myattr': hook3})
+    var fourth = h('div', {})
 
-    var elem = createElement(left)
+    var elem = createElement(first)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'first value')
 
-    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'the value')
-
-    var patches = diff(left, right)
-
+    var patches = diff(first, second)
     patch(elem, patches)
+    // The value shouldn't change.
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'first value')
 
+    patches = diff(second, third)
+    patch(elem, patches)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'second value')
+
+    patches = diff(third, fourth)
+    patch(elem, patches)
     assert.equal(elem.getAttributeNS(namespace, 'myattr'), blankAttributeNS())
 
     assert.end()

--- a/virtual-hyperscript/test/attribute-hook.js
+++ b/virtual-hyperscript/test/attribute-hook.js
@@ -38,6 +38,94 @@ test("sets and removes namespaced attribute", function (assert) {
     assert.end()
 })
 
+test("sets the attribute if previous value was not an AttributeHook", function (assert) {
+    var namespace = 'http://ns.com/my'
+
+    var OtherHook = function(namespace, value) {
+        this.namespace = namespace
+        this.value = value
+    }
+    OtherHook.prototype.hook = function() {}
+
+    var hook1 = new OtherHook(namespace, 'the value')
+    var hook2 = attributeHook(namespace, 'the value')
+
+    var first = h('div', {'myns:myattr': hook1})
+    var second = h('div', {'myns:myattr': hook2})
+
+    var elem = createElement(first)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), blankAttributeNS())
+
+    patches = diff(first, second)
+    patch(elem, patches)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'the value')
+
+    assert.end()
+})
+
+test("sets the attribute if previous value uses a different namespace", function (assert) {
+    var namespace = 'http://ns.com/my'
+
+    var hook1 = attributeHook('http://other.ns/', 'the value')
+    var hook2 = attributeHook(namespace, 'the value')
+
+    var first = h('div', {'myns:myattr': hook1})
+    var second = h('div', {'myns:myattr': hook2})
+
+    var elem = createElement(first)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), blankAttributeNS())
+
+    patches = diff(first, second)
+    patch(elem, patches)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'the value')
+
+    assert.end()
+})
+
+test("removes the attribute if next value is not an AttributeHook", function (assert) {
+    var namespace = 'http://ns.com/my'
+
+    var OtherHook = function(namespace, value) {
+        this.namespace = namespace
+        this.value = value
+    }
+    OtherHook.prototype.hook = function() {}
+
+    var hook1 = attributeHook(namespace, 'the value')
+    var hook2 = new OtherHook(namespace, 'the value')
+
+    var first = h('div', {'myns:myattr': hook1})
+    var second = h('div', {'myns:myattr': hook2})
+
+    var elem = createElement(first)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'the value')
+
+    patches = diff(first, second)
+    patch(elem, patches)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), blankAttributeNS())
+
+    assert.end()
+})
+
+test("removes the attribute if next value uses a different namespace", function (assert) {
+    var namespace = 'http://ns.com/my'
+
+    var hook1 = attributeHook(namespace, 'the value')
+    var hook2 = attributeHook('http://other.ns/', 'the value')
+
+    var first = h('div', {'myns:myattr': hook1})
+    var second = h('div', {'myns:myattr': hook2})
+
+    var elem = createElement(first)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), 'the value')
+
+    patches = diff(first, second)
+    patch(elem, patches)
+    assert.equal(elem.getAttributeNS(namespace, 'myattr'), blankAttributeNS())
+
+    assert.end()
+})
+
 function blankAttributeNS() {
     // Most browsers conform to the latest version of the DOM spec,
     // which requires `getAttributeNS` to return `null` when the attribute


### PR DESCRIPTION
The patch adds a third parameter to `unhook()` - the next instance of the hook, or `undefined` if the hook is removed.

This is consistent with `hook()`, which receives the previous instance as the third parameter.

As of 4aedb4a3697b7e3f3eee11f769e20a02de5c534f, `unhook()` is invoked every time the hook gets patched. The next instance can be used to determine whether `unhook()` can avoid doing unnecessary work, for example:

    MyHook.prototype.unhook = function(node, prop, next) {
      if (next && next.value === this.value) {
        return
      }
      // ... do work ...
    }

The new parameter is then used to fix a bug in `AttributeHook` where attribute that didn't change were accidentally removed when re-rendering the node.