### PR TITLE
improved performance of parseTag method for the common case

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "email": "matt@mattesch.info"
   },
   "dependencies": {
-    "browser-split": "0.0.1",
     "error": "^4.3.0",
     "ev-store": "^7.0.0",
     "global": "^4.3.0",

--- a/virtual-hyperscript/parse-tag.js
+++ b/virtual-hyperscript/parse-tag.js
@@ -1,10 +1,5 @@
 'use strict';
 
-var split = require('browser-split');
-
-var classIdSplit = /([\.#]?[a-zA-Z0-9_:-]+)/;
-var notClassId = /^\.|#/;
-
 module.exports = parseTag;
 
 function parseTag(tag, props) {
@@ -14,16 +9,13 @@ function parseTag(tag, props) {
 
     var noId = !(props.hasOwnProperty('id'));
 
-    var tagParts = split(tag, classIdSplit);
-    var tagName = null;
+    var tagParts = splitTag(tag);
 
-    if (notClassId.test(tagParts[1])) {
-        tagName = 'DIV';
-    }
+    var tagName = tagParts[0] || 'DIV';
 
     var classes, part, type, i;
 
-    for (i = 0; i < tagParts.length; i++) {
+    for (i = 1; i < tagParts.length; i++) {
         part = tagParts[i];
 
         if (!part) {
@@ -32,9 +24,7 @@ function parseTag(tag, props) {
 
         type = part.charAt(0);
 
-        if (!tagName) {
-            tagName = part;
-        } else if (type === '.') {
+        if (type === '.') {
             classes = classes || [];
             classes.push(part.substring(1, part.length));
         } else if (type === '#' && noId) {
@@ -51,4 +41,32 @@ function parseTag(tag, props) {
     }
 
     return props.namespace ? tagName : tagName.toUpperCase();
+}
+
+
+function splitTag(tag) {
+
+    var classIndex, idIndex,
+        remaining = tag,
+        parts = [],
+        last = '';
+
+    do {
+        idIndex = remaining.indexOf('#');
+        classIndex = remaining.indexOf('.');
+        if ((idIndex === -1 || idIndex > classIndex) && classIndex !== -1) {
+            parts.push(last + remaining.substr(0, classIndex));
+            last = '.';
+            remaining = remaining.substr(classIndex + 1);
+        } else if (idIndex !== -1){
+            parts.push(last + remaining.substr(0, idIndex));
+            last = '#';
+            remaining = remaining.substr(idIndex + 1);
+        }
+
+    } while(idIndex !== -1 || classIndex !== -1)
+
+    parts.push(last + remaining);
+
+    return parts;
 }

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -176,3 +176,22 @@ test("h with two ids", function (assert) {
 
     assert.end()
 })
+
+test("h with tag and two classes", function (assert) {
+    var node = h("div.foo.bar")
+
+    assert.equal(node.tagName, "DIV")
+    assert.equal(node.properties.className, "foo bar")
+
+    assert.end()
+})
+
+test("h with tag, id and class", function (assert) {
+    var node = h("div#foo.bar")
+
+    assert.equal(node.tagName, "DIV")
+    assert.equal(node.properties.id, "foo")
+    assert.equal(node.properties.className, "bar")
+
+    assert.end()
+})


### PR DESCRIPTION
Hello,

I've been playing around with virtual-dom lately and created my own todomvc app with it. When testing I noticed that my version was significantly slower than mercurys reference example. This seemed odd as they both used the virtual-dom library. Upon doing some profiling I found the culprit to be the browser-split method which was introduced in 900d332 , I'm guessing in order to deal with some browser inconsistencies with splitting a string using regex.

Anyways, in this pull request I've avoided using the browser-split method if the tag passed into `parseTag` does not contain any id's or class selectors. This greatly increased the performance of the common case (a plain tag) but heavy usage of `div#id.selector` notation will remain slow. 

Was browser-split introduced because of an existing incompatibility of supported browsers or as a pre-emptive measure ? Can it be changed back to `String.prototype.split` ?

Here are the basic benchmarks:

``` javascript
       var renderAll = function() {
            var list = [];
            for (var i =0; i < 1000; i++) list.push(renderOne(String(i));

            return h('div', list);
        }

        var renderOne = function(v) {
            return h('div', [
                h('input', {type: 'text'}, v ),
                h('div', v),
                h('label', v),
                h('span', v),
                h('p', v)
            ]);
        }
```

Before:

``` javascript
var t =performance.now() ; renderAll(); performance.now() - t; //287.14299999410287
```

After:

``` javascript
var t =performance.now() ; renderAll(); performance.now() - t; //20.79000003868714
```
