### PR TITLE
Rewrite reorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .DS_Store
 .monitor
 .*.swp

--- a/test/keys.js
+++ b/test/keys.js
@@ -443,9 +443,9 @@ test("adding multiple widgets", function (assert) {
     assert.end()
 })
 
-test('grids of 3x2, 3x1 then 3x2', function (assert) {
-    function item(x, y) {
-        var key = x + '-' + y
+test.only('grids of 3x2, 3x1 then 3x2', function (assert) {
+    function item(key) {
+        key = key.toString()
         return h('div', {key: key}, key)
     }
 
@@ -454,31 +454,30 @@ test('grids of 3x2, 3x1 then 3x2', function (assert) {
     }
 
     var gridOf3x2 = container([
-        item(0, 0),
-        item(1, 0),
-        item(0, 1),
-        item(1, 1),
-        item(0, 2),
-        item(1, 2)
+        item(0),
+        item(1),
+        item(2),
+        item(3),
+        item(4),
+        item(5)
     ])
 
     var gridOf3x1 = container([
-        item(0, 0),
-        item(0, 1),
-        item(0, 2)
+        item(0),
+        item(2),
+        item(4)
     ])
 
     var rootNode = render(gridOf3x1)
     rootNode = patch(rootNode, diff(gridOf3x1, gridOf3x2))
-    rootNode = patch(rootNode, diff(gridOf3x2, gridOf3x1))
 
     function expectTextOfChild(childNo, text) {
         assert.equal(rootNode.childNodes[childNo].textContent, text)
     }
 
-    expectTextOfChild(0, '0-0')
-    expectTextOfChild(1, '0-1')
-    expectTextOfChild(2, '0-2')
+    for (var i = 0; i <= 5; i++) {
+        expectTextOfChild(i, i.toString())
+    }
 })
 
 function childNodesArray(node) {

--- a/test/keys.js
+++ b/test/keys.js
@@ -496,7 +496,7 @@ test('3 elements in a container, insert an element after each', function (assert
 })
 
 test('10 elements in a container, remove every second element', function(assert) {
-   var  fiveItems = itemHelpers.itemsInContainer().from(0).to(8).by(2)
+    var  fiveItems = itemHelpers.itemsInContainer().from(0).to(8).by(2)
     var tenItems = itemHelpers.itemsInContainer().from(0).to(9).by(1)
 
     var rootNode = render(tenItems)
@@ -514,23 +514,33 @@ test('10 elements in a container, remove every second element', function(assert)
     assert.end();
 })
 
-test('5 elements in a container, insert an element after every second element', function (assert) {
-    function everySecondOrThird(i) {
-        return i % 3 == 0 || i % 3 == 1
-    }
+test('3 elements in a container, add 3 elements after each', function (assert) {
+    var first = itemHelpers.itemsInContainer().from(0).to(12).by(4)
+    var second = itemHelpers.itemsInContainer().from(0).to(12).by(1)
 
-    var tenItems = itemHelpers.itemsInContainer().from(0).to(9).withPredicate(everySecondOrThird)
-    var fifteenItems = itemHelpers.itemsInContainer().from(0).to(14).by(1)
+    var rootNode = render(first)
+    rootNode = patch(rootNode, diff(first, second))
 
-    var rootNode = render(tenItems)
-    rootNode = patch(rootNode, diff(tenItems, fifteenItems))
-
-    for (var i = 0; i < 15; i++) {
+    for (var i = 0; i <= 12; i++) {
         itemHelpers.expectTextOfChild(assert, rootNode, i, i.toString())
     }
 })
 
-test('10 elements in a container')
+test('10 elements in a container, add an element after every second element', function (assert) {
+    function skipEveryThird(i) {
+        return i % 3 == 0 || i % 3 == 1
+    }
+
+    var first = itemHelpers.itemsInContainer().from(0).to(14).withPredicate(skipEveryThird)
+    var second = itemHelpers.itemsInContainer().from(0).to(14).by(1)
+
+    var rootNode = render(first)
+    rootNode = patch(rootNode, diff(first, second))
+
+    for (var i = 0; i <= 14; i++) {
+        itemHelpers.expectTextOfChild(assert, rootNode, i, i.toString())
+    }
+})
 
 function childNodesArray(node) {
     var childNodes = []

--- a/test/keys.js
+++ b/test/keys.js
@@ -243,8 +243,6 @@ test("delete key at the start", function (assert) {
     var childNodes = childNodesArray(rootNode)
 
     var patches = diff(leftNode, rightNode)
-    // just a remove patch
-    assert.equal(patchCount(patches), 1)
 
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
@@ -507,9 +505,6 @@ test('10 elements in a container, remove every second element', function(assert)
 
     var rootNode = render(tenItems)
     var patches = diff(tenItems, fiveItems)
-
-    // 5 remove patches only
-    assert.equal(patchCount(patches), 5)
 
     rootNode = patch(rootNode, patches)
 

--- a/test/keys.js
+++ b/test/keys.js
@@ -443,7 +443,7 @@ test("adding multiple widgets", function (assert) {
     assert.end()
 })
 
-test.only('grids of 3x2, 3x1 then 3x2', function (assert) {
+test('3 elements in a container, insert an element after each', function (assert) {
     function item(key) {
         key = key.toString()
         return h('div', {key: key}, key)
@@ -453,7 +453,13 @@ test.only('grids of 3x2, 3x1 then 3x2', function (assert) {
         return h('div', children)
     }
 
-    var gridOf3x2 = container([
+    var threeItems = container([
+        item(0),
+        item(2),
+        item(4)
+    ])
+
+    var sixItems = container([
         item(0),
         item(1),
         item(2),
@@ -462,14 +468,8 @@ test.only('grids of 3x2, 3x1 then 3x2', function (assert) {
         item(5)
     ])
 
-    var gridOf3x1 = container([
-        item(0),
-        item(2),
-        item(4)
-    ])
-
-    var rootNode = render(gridOf3x1)
-    rootNode = patch(rootNode, diff(gridOf3x1, gridOf3x2))
+    var rootNode = render(threeItems)
+    rootNode = patch(rootNode, diff(threeItems, sixItems))
 
     function expectTextOfChild(childNo, text) {
         assert.equal(rootNode.childNodes[childNo].textContent, text)

--- a/test/keys.js
+++ b/test/keys.js
@@ -443,6 +443,44 @@ test("adding multiple widgets", function (assert) {
     assert.end()
 })
 
+test('grids of 3x2, 3x1 then 3x2', function (assert) {
+    function item(x, y) {
+        var key = x + '-' + y
+        return h('div', {key: key}, key)
+    }
+
+    function container(children) {
+        return h('div', children)
+    }
+
+    var gridOf3x2 = container([
+        item(0, 0),
+        item(1, 0),
+        item(0, 1),
+        item(1, 1),
+        item(0, 2),
+        item(1, 2)
+    ])
+
+    var gridOf3x1 = container([
+        item(0, 0),
+        item(0, 1),
+        item(0, 2)
+    ])
+
+    var rootNode = render(gridOf3x1)
+    rootNode = patch(rootNode, diff(gridOf3x1, gridOf3x2))
+    rootNode = patch(rootNode, diff(gridOf3x2, gridOf3x1))
+
+    function expectTextOfChild(childNo, text) {
+        assert.equal(rootNode.childNodes[childNo].textContent, text)
+    }
+
+    expectTextOfChild(0, '0-0')
+    expectTextOfChild(1, '0-1')
+    expectTextOfChild(2, '0-2')
+})
+
 function childNodesArray(node) {
     var childNodes = []
     for (var i = 0; i < node.childNodes.length; i++) {

--- a/test/keys.js
+++ b/test/keys.js
@@ -243,7 +243,8 @@ test("delete key at the start", function (assert) {
     var childNodes = childNodesArray(rootNode)
 
     var patches = diff(leftNode, rightNode)
-    assert.equal(patchCount(patches), 2)
+    // just a remove patch
+    assert.equal(patchCount(patches), 1)
 
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
@@ -299,7 +300,8 @@ test("delete key at the end", function (assert) {
     var childNodes = childNodesArray(rootNode)
 
     var patches = diff(leftNode, rightNode)
-    assert.equal(patchCount(patches), 2)
+    // just a remove patch
+    assert.equal(patchCount(patches), 1)
 
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
@@ -341,17 +343,17 @@ test("add key to end", function (assert) {
 
 test("add to end and delete from center & reverse", function (assert) {
     var leftNode = h("div", [
-        h("div", { key: "a" }, "a"),
-        h("div", { key: "b" }, "b"),
-        h("div", { key: "c" }, "c"),
-        h("div", { key: "d" }, "d")
+        h("div", { key: "a", id: "a" }, "a"),
+        h("div", { key: "b", id: "b" }, "b"),
+        h("div", { key: "c", id: "c" }, "c"),
+        h("div", { key: "d", id: "d" }, "d")
     ])
 
     var rightNode = h("div", [
-        h("div", { key: "e" }, "e"),
-        h("div", { key: "d" }, "d"),
-        h("div", { key: "c" }, "c"),
-        h("div", { key: "a" }, "a")
+        h("div", { key: "e", id: "e" }, "e"),
+        h("div", { key: "d", id: "d" }, "d"),
+        h("div", { key: "c", id: "c" }, "c"),
+        h("div", { key: "a", id: "a" }, "a")
     ])
 
     var rootNode = render(leftNode)
@@ -509,14 +511,19 @@ test('10 elements in a container, remove every second element', function(assert)
     })())
 
     var rootNode = render(tenItems)
-    rootNode = patch(rootNode, diff(tenItems, fiveItems))
+    var patches = diff(tenItems, fiveItems)
+
+    // 5 remove patches only
+    assert.equal(patchCount(patches), 5)
+
+    rootNode = patch(rootNode, patches)
 
     function expectTextOfChild(childNo, text) {
         assert.equal(rootNode.childNodes[childNo].id, text)
     }
 
-    for (var i = 0; i < 10; i += 2) {
-        expectTextOfChild(i, i.toString())
+    for (var i = 0; i < 5; i++) {
+        expectTextOfChild(i, (i * 2).toString())
     }
 
     assert.end();

--- a/test/keys.js
+++ b/test/keys.js
@@ -482,6 +482,46 @@ test('3 elements in a container, insert an element after each', function (assert
     assert.end();
 })
 
+test('10 elements in a container, remove every second element', function(assert) {
+    function item(key) {
+        key = key.toString()
+        return h('div', {key: key, id: key}, key)
+    }
+
+    function container(children) {
+        return h('div', children)
+    }
+
+    fiveItems = container([
+        item(0),
+        item(2),
+        item(4),
+        item(6),
+        item(8)
+    ])
+
+    tenItems = container((function (){
+        items = []
+        for (var i = 0; i < 10; i++){
+            items.push(item(i))
+        }
+        return items
+    })())
+
+    var rootNode = render(tenItems)
+    rootNode = patch(rootNode, diff(tenItems, fiveItems))
+
+    function expectTextOfChild(childNo, text) {
+        assert.equal(rootNode.childNodes[childNo].id, text)
+    }
+
+    for (var i = 0; i < 10; i += 2) {
+        expectTextOfChild(i, i.toString())
+    }
+
+    assert.end();
+})
+
 function childNodesArray(node) {
     var childNodes = []
     for (var i = 0; i < node.childNodes.length; i++) {

--- a/test/keys.js
+++ b/test/keys.js
@@ -445,6 +445,35 @@ test("adding multiple widgets", function (assert) {
     assert.end()
 })
 
+itemHelpers = {
+    item: function (key) {
+        key = key.toString()
+        return h('div', {key: key, id: key}, key)
+    },
+
+    container: function (children) {
+        return h('div', children)
+    },
+
+    itemsInContainer: function () {
+        return { from: function (start) {
+            return { to: function (end) {
+                return {by: function (increment) {
+                    var items = []
+                    for (var i = start; i <= end; i += increment) {
+                        items.push(itemHelpers.item(i))
+                    }
+                    return itemHelpers.container(items)
+                } }
+            } }
+        } }
+    },
+
+    expectTextOfChild: function (assert, rootNode, childNo, text) {
+        assert.equal(rootNode.childNodes[childNo].id, text)
+    }
+}
+
 test('3 elements in a container, insert an element after each', function (assert) {
     function item(key) {
         key = key.toString()
@@ -455,60 +484,22 @@ test('3 elements in a container, insert an element after each', function (assert
         return h('div', children)
     }
 
-    var threeItems = container([
-        item(0),
-        item(2),
-        item(4)
-    ])
-
-    var sixItems = container([
-        item(0),
-        item(1),
-        item(2),
-        item(3),
-        item(4),
-        item(5)
-    ])
+    var threeItems = itemHelpers.itemsInContainer().from(0).to(4).by(2)
+    var sixItems = itemHelpers.itemsInContainer().from(0).to(5).by(1)
 
     var rootNode = render(threeItems)
     rootNode = patch(rootNode, diff(threeItems, sixItems))
 
-    function expectTextOfChild(childNo, text) {
-        assert.equal(rootNode.childNodes[childNo].id, text)
-    }
-
     for (var i = 0; i <= 5; i++) {
-        expectTextOfChild(i, i.toString())
+        itemHelpers.expectTextOfChild(assert, rootNode, i, i.toString())
     }
 
     assert.end();
 })
 
 test('10 elements in a container, remove every second element', function(assert) {
-    function item(key) {
-        key = key.toString()
-        return h('div', {key: key, id: key}, key)
-    }
-
-    function container(children) {
-        return h('div', children)
-    }
-
-    fiveItems = container([
-        item(0),
-        item(2),
-        item(4),
-        item(6),
-        item(8)
-    ])
-
-    tenItems = container((function (){
-        items = []
-        for (var i = 0; i < 10; i++){
-            items.push(item(i))
-        }
-        return items
-    })())
+    fiveItems = itemHelpers.itemsInContainer().from(0).to(8).by(2)
+    tenItems = itemHelpers.itemsInContainer().from(0).to(10).by(1)
 
     var rootNode = render(tenItems)
     var patches = diff(tenItems, fiveItems)
@@ -518,16 +509,14 @@ test('10 elements in a container, remove every second element', function(assert)
 
     rootNode = patch(rootNode, patches)
 
-    function expectTextOfChild(childNo, text) {
-        assert.equal(rootNode.childNodes[childNo].id, text)
-    }
-
     for (var i = 0; i < 5; i++) {
-        expectTextOfChild(i, (i * 2).toString())
+        itemHelpers.expectTextOfChild(assert, rootNode, i, (i * 2).toString())
     }
 
     assert.end();
 })
+
+test('10 elements in a container')
 
 function childNodesArray(node) {
     var childNodes = []

--- a/test/keys.js
+++ b/test/keys.js
@@ -446,7 +446,7 @@ test("adding multiple widgets", function (assert) {
 test('3 elements in a container, insert an element after each', function (assert) {
     function item(key) {
         key = key.toString()
-        return h('div', {key: key}, key)
+        return h('div', {key: key, id: key}, key)
     }
 
     function container(children) {
@@ -472,12 +472,14 @@ test('3 elements in a container, insert an element after each', function (assert
     rootNode = patch(rootNode, diff(threeItems, sixItems))
 
     function expectTextOfChild(childNo, text) {
-        assert.equal(rootNode.childNodes[childNo].textContent, text)
+        assert.equal(rootNode.childNodes[childNo].id, text)
     }
 
     for (var i = 0; i <= 5; i++) {
         expectTextOfChild(i, i.toString())
     }
+
+    assert.end();
 })
 
 function childNodesArray(node) {

--- a/test/lib/assert-childNodes-from-array.js
+++ b/test/lib/assert-childNodes-from-array.js
@@ -1,0 +1,11 @@
+module.exports = assertChildNodesFromArray;
+
+function assertChildNodesFromArray(assert, items, childNodes) {
+    // ensure that the output has the same number of nodes as required
+    assert.equal(childNodes.length, items.length)
+
+    for (var i = 0; i < items.length; i++) {
+        var key = items[i]
+        assert.equal(childNodes[i].id, key != null ? String(key) : 'no-key-' + i)
+    }
+}

--- a/test/lib/nodes-from-array.js
+++ b/test/lib/nodes-from-array.js
@@ -1,0 +1,30 @@
+var h = require("../../h.js")
+
+module.exports = nodesFromArray
+
+function nodesFromArray(array) {
+    var i =0
+    var children = []
+    var key
+    var properties
+
+    for(; i < array.length; i++) {
+        key = array[i]
+
+        if (key != null) {
+            properties = {
+                key: key,
+                id: String(key)
+            }
+        }
+        else {
+            properties = {
+                id: 'no-key-' + i
+            }
+        }
+
+        children.push(h('div', properties, properties.id))
+    }
+
+    return h('div', children)
+}

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,0 +1,271 @@
+//
+// This tests the performance of a potential sort approach in vtree/diff.
+// The benchmark contains the actual code which returns the sorted array
+// instead of the moves so we can more efficiently verify the results of the
+// algorithm. The move objects are still generated to preserve similarity.
+//
+// This test in it's current configuration will test every array permutation of
+// N numbers from 0, 2, ... N  for N = 1 up to and including N = 9.
+//
+// Furthermore, arrays for N 10, 20, 30, ... 1000 are tested. Since the number
+// of permutations is a factorial problem, we can't test all permutations for
+// these. We generate 100 arrays instead and randomly shuffle them for testing.
+//
+// Each test is timed in a benchmark version of the test which removes the
+// peripheral operations, and each test is also re-run against a validation
+// version, which checks to ensure that the arrays are actually sorted.
+//
+// Essentially this test proves that the sorting algorithm for N 0-based
+// consecutive integers works for ALL permutations up to length 9.
+//
+// Some work was done to experiment on the performance of the array move
+// operation. It appears that the slice approach is always faster in modern
+// browsers. Further work is required to see how the performance profile
+// changes in other browsers.
+//
+
+var PERMUTATION_START = 1;
+var PERMUTATION_END = 9;
+
+var SAMPLE_START = 10;
+var SAMPLE_END = 1000;
+var SAMPLE_COUNT = 100;
+var SAMPLE_INTERVAL = 10;
+
+var move = moveSplice;  // Splice appears to be faster in benchmarks
+
+runTest();
+// validateOnly();
+// benchmarkOnly();
+
+function runTest() {
+    forEachPermutation(PERMUTATION_START, PERMUTATION_END, testArrays);
+    forEachSample(SAMPLE_START, SAMPLE_END, SAMPLE_COUNT, SAMPLE_INTERVAL, testArrays);
+}
+
+function testArrays(arrays) {
+    runSort(arrays);
+    runBench(arrays);
+}
+
+function validateOnly() {
+    forEachPermutation(PERMUTATION_START, PERMUTATION_END, runSort);
+    forEachSample(SAMPLE_START, SAMPLE_END, SAMPLE_COUNT, SAMPLE_INTERVAL, runSort);
+}
+
+function benchmarkOnly() {
+    forEachPermutation(PERMUTATION_START, PERMUTATION_END, runBench);
+    forEachSample(SAMPLE_START, SAMPLE_END, SAMPLE_COUNT, SAMPLE_INTERVAL, runBench);
+}
+
+function runBench(permutations) {
+    var count = permutations.length;
+    var arrayLength = permutations[0].length;
+
+    console.log('Benchmarking sort for length ', arrayLength);
+
+    var startTime = Date.now();
+
+    for (var i = 0; i < count; i++) {
+        sort(permutations[i]);
+    }
+
+    var totalTime = Date.now() - startTime;
+    var average = totalTime / count >> 0
+
+    console.log('All (' + count + ') arrays sorted in', totalTime, 'ms');
+    console.log('An array of length', arrayLength, 'sorts in', average, 'ms');
+}
+
+function runSort(permutations) {
+    var count = permutations.length;
+    var arrayLength = permutations[0].length;
+
+    console.log('Testing sort for length ', permutations[0].length);
+
+    for (var i = 0; i < count; i++) {
+        var sorted = sort(permutations[i]);
+        assertSorted(sorted, arrayLength);
+    }
+
+    console.log('All permutations sorted correctly');
+}
+
+function assertSorted(sorted, length) {
+    if (sorted.length !== length) {
+        throw new Error("Sorted array is longer than expected");
+    }
+
+    var testSorted = sorted.slice().sort(numericalSort);
+
+    for (var i = 0; i < testSorted.length; i++) {
+        if (testSorted[i] !== sorted[i]) {
+            console.log(sorted);
+            console.log(testSorted);
+            throw new Error("UNSORTED ARRAY");
+        }
+    }
+}
+
+function numericalSort(a, b) {
+    return a > b ? 1 : a < b ? -1 : 0;
+}
+
+function forEachPermutation(start, end, run) {
+    for (var arrayLength = start; arrayLength <= end; arrayLength++) {
+        var array = createArray(arrayLength);
+
+        console.log('Generating test permutations for length', arrayLength);
+        var permutations = permutator(array);
+
+        run(permutations);
+    }
+}
+
+function permutator(inputArr) {
+    var results = [];
+
+    function permute(arr, memo) {
+        var cur, memo = memo || [];
+
+        for (var i = 0; i < arr.length; i++) {
+            cur = arr.splice(i, 1);
+            if (arr.length === 0) {
+                results.push(memo.concat(cur));
+            }
+            permute(arr.slice(), memo.concat(cur));
+            arr.splice(i, 0, cur[0]);
+        }
+
+        return results;
+    }
+
+    return permute(inputArr);
+}
+
+function forEachSample(start, end, count, interval, run) {
+    console.log(arguments);
+    for (var i = start; i <= end; i += interval) {
+        var samples = new Array(count);
+
+        console.log("Generating", count, "sample arrays of length", i);
+
+        for (j = 0; j < count; j++) {
+            samples[j] = shuffle(createArray(i));
+        }
+
+        run(samples);
+    }
+}
+
+function createArray(arrayLength) {
+    var array = new Array(arrayLength);
+
+    for (var numberToAdd = 0; numberToAdd < arrayLength; numberToAdd++) {
+        array[numberToAdd] = numberToAdd;
+    }
+
+    return array;
+}
+
+function shuffle(array) {
+    var currentIndex = array.length;
+    var temporaryValue;
+    var randomIndex;
+
+    while (0 !== currentIndex) {
+        randomIndex = Math.floor(Math.random() * currentIndex);
+        currentIndex -= 1;
+
+        temporaryValue = array[currentIndex];
+        array[currentIndex] = array[randomIndex];
+        array[randomIndex] = temporaryValue;
+    }
+
+    return array;
+}
+
+
+//
+// Code to test/benchmark code begins ----------------------------------------
+//
+
+function sort(arr) {
+    var arrLength = arr.length;
+    var moves = [];
+
+    for (var i = 0; i < arrLength; i++) {
+        var item = arr[i];
+
+        if (item !== i) {
+            var desiredItemIndex = 0;
+            var swapDestination = 0;
+            var lessThanSearchHalt = item - i;
+            var lessThanSearchCount = 0;
+
+            for (var j = i + 1; j < arrLength; j++) {
+                var compareItem = arr[j];
+
+                if (compareItem < item) {
+                    lessThanSearchCount += 1;
+                    if (lessThanSearchCount === lessThanSearchHalt) {
+                        swapDestination = j + 1;
+                    }
+                }
+
+                if (compareItem === i) {
+                    desiredItemIndex = j;
+                }
+
+                if (desiredItemIndex > 0 && swapDestination > 0) {
+                    break;
+                }
+            }
+
+            if (swapDestination > desiredItemIndex + 1) {
+                moves.push(move(arr, i, swapDestination));
+                i--;
+            } else {
+                moves.push(move(arr, desiredItemIndex, i));
+            }
+        }
+    }
+
+    return arr
+}
+
+function moveSplice(array, from, to) {
+    array.splice(from < to ? to - 1 : to, 0, array.splice(from, 1)[0]);
+
+    return {
+        from: from,
+        to: to
+    };
+}
+
+
+// Shift instead of splice - slower in benchmarks
+function moveShift(arr, from, to) {
+    var fromItem = arr[from];
+    var i;
+    var end;
+
+    if (from < to) {
+        end = to - 1;
+        for (i = from; i < end; i++) {
+            arr[i] = arr[i + 1];
+        }
+    } else {
+        end = to;
+        for (i = from; i > to; i--) {
+            arr[i] = arr[i - 1];
+        }
+    }
+
+    arr[end] = fromItem;
+
+    return {
+        from: from,
+        to: to
+    };
+}

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -120,20 +120,26 @@ function destroyWidget(domNode, w) {
 
 function reorderChildren(domNode, moves) {
     var childNodes = domNode.childNodes
+    var keyMap = {}
+    var node
+    var remove
+    var insert
 
-    for (var i = 0; i < moves.length; i++) {
-        var move = moves[i]
-        var from = move.from;
-        var to = move.to;
-
-        if (to >= 0) {
-            domNode.insertBefore(
-                childNodes[move.from],
-                childNodes[move.to]
-            )
-        } else {
-            domNode.removeChild(childNodes[from])
+    for (var i = 0; i < moves.removes.length; i++) {
+        remove = moves.removes[i]
+        node = childNodes[remove.from]
+        if (remove.key) {
+            keyMap[remove.key] = node
         }
+        domNode.removeChild(node)
+    }
+
+    var length = childNodes.length
+    for (var j = 0; j < moves.inserts.length; j++) {
+        insert = moves.inserts[j]
+        node = keyMap[insert.key]
+        // this is the weirdest bug i've ever seen in webkit
+        domNode.insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
     }
 }
 

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -160,7 +160,7 @@ function reorderChildren(domNode, bIndex) {
             }
 
             // the moved element came from the front of the array so reduce the insert offset
-            if (move + chainLength < i) {
+            if (move + chainLength <= i) {
                 insertOffset--
             }
         }

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -130,6 +130,7 @@ function reorderChildren(domNode, bIndex) {
     }
 
     var insertOffset = 0
+    var removeOffset = 0
     var move
     var node
     var insertNode
@@ -138,6 +139,13 @@ function reorderChildren(domNode, bIndex) {
     for (i = 0; i < len;) {
         move = bIndex[i]
         chainLength = 1
+
+        // element at this index is scheduled to be removed so increase insert offset
+        if (i + removeOffset in bIndex.removes) {
+            removeOffset++
+            insertOffset++
+        }
+
         if (move !== undefined && move !== i) {
             // try to bring forward as long of a chain as possible
             while (bIndex[i + chainLength] === move + chainLength) {
@@ -163,11 +171,6 @@ function reorderChildren(domNode, bIndex) {
             if (move + chainLength <= i) {
                 insertOffset--
             }
-        }
-
-        // element at this index is scheduled to be removed so increase insert offset
-        if (i in bIndex.removes) {
-            insertOffset++
         }
 
         i += chainLength

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -123,10 +123,17 @@ function reorderChildren(domNode, moves) {
 
     for (var i = 0; i < moves.length; i++) {
         var move = moves[i]
-        domNode.insertBefore(
-            childNodes[move.from],
-            childNodes[move.to]
-        )
+        var from = move.from;
+        var to = move.to;
+
+        if (to >= 0) {
+            domNode.insertBefore(
+                childNodes[move.from],
+                childNodes[move.to]
+            )
+        } else {
+            domNode.removeChild(childNodes[from])
+        }
     }
 }
 

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -118,62 +118,15 @@ function destroyWidget(domNode, w) {
     }
 }
 
-function reorderChildren(domNode, bIndex) {
-    var children = []
+function reorderChildren(domNode, moves) {
     var childNodes = domNode.childNodes
-    var len = childNodes.length
-    var i
-    var reverseIndex = bIndex.reverse
 
-    for (i = 0; i < len; i++) {
-        children.push(domNode.childNodes[i])
-    }
-
-    var insertOffset = 0
-    var removeOffset = 0
-    var move
-    var node
-    var insertNode
-    var chainLength
-    var insertedLength
-    for (i = 0; i < len;) {
-        move = bIndex[i]
-        chainLength = 1
-
-        // element at this index is scheduled to be removed so increase insert offset
-        if (i + removeOffset in bIndex.removes) {
-            removeOffset++
-            insertOffset++
-        }
-
-        if (move !== undefined && move !== i) {
-            // try to bring forward as long of a chain as possible
-            while (bIndex[i + chainLength] === move + chainLength) {
-                chainLength++;
-            }
-
-            node = children[move]
-            insertNode = childNodes[i + insertOffset] || null
-            insertedLength = 0
-            while (node !== insertNode && insertedLength++ < chainLength) {
-                if (!insertNode || insertNode.previousSibling !== node) {
-                    domNode.insertBefore(node, insertNode);
-                }
-                node = children[move + insertedLength];
-            }
-
-            // the element currently at this index will be moved later so increase the insert offset
-            if (reverseIndex[i] >= i + chainLength) {
-                insertOffset++
-            }
-
-            // the moved element came from the front of the array so reduce the insert offset
-            if (move + chainLength <= i) {
-                insertOffset--
-            }
-        }
-
-        i += chainLength
+    for (var i = 0; i < moves.length; i++) {
+        var move = moves[i]
+        domNode.insertBefore(
+            childNodes[move.from],
+            childNodes[move.to]
+        )
     }
 }
 

--- a/vtree/diff.js
+++ b/vtree/diff.js
@@ -247,6 +247,7 @@ function reorder(aChildren, bChildren) {
     var moveIndex = 0
     var moves = {}
     var removes = moves.removes = {}
+    var removeCount = 0
     var reverse = moves.reverse = {}
     var hasMoves = false
 
@@ -254,7 +255,7 @@ function reorder(aChildren, bChildren) {
         var move = aMatch[i]
         if (move !== undefined) {
             shuffle[i] = bChildren[move]
-            if (move !== moveIndex) {
+            if (move !== moveIndex - removeCount) {
                 moves[move] = moveIndex
                 reverse[moveIndex] = move
                 hasMoves = true
@@ -263,7 +264,7 @@ function reorder(aChildren, bChildren) {
         } else if (i in aMatch) {
             shuffle[i] = undefined
             removes[i] = moveIndex++
-            hasMoves = true
+            removeCount++
         } else {
             while (bMatch[freeIndex] !== undefined) {
                 freeIndex++

--- a/vtree/diff.js
+++ b/vtree/diff.js
@@ -110,7 +110,7 @@ function diffChildren(a, b, patch, apply, index) {
         }
     }
 
-    if (orderedSet.moves.length > 0) {
+    if (orderedSet.moves) {
         // Reorder nodes last
         apply = appendPatch(apply, new VPatch(
             VPatch.ORDER,
@@ -224,12 +224,11 @@ function reorder(aChildren, bChildren) {
     var bChildIndex = keyIndex(bChildren)
     var bKeys = bChildIndex.keys
     var bFree = bChildIndex.free
-    var moves = []
 
     if (bFree.length === bChildren.length) {
         return {
             children: bChildren,
-            moves: moves
+            moves: null
         }
     }
 
@@ -241,13 +240,12 @@ function reorder(aChildren, bChildren) {
     if (aFree.length === aChildren.length) {
         return {
             children: bChildren,
-            moves: moves
+            moves: null
         }
     }
 
     // O(MAX(N, M)) memory
     var newChildren = []
-    var sortOrder = []
 
     var freeIndex = 0
     var freeCount = bFree.length
@@ -264,36 +262,23 @@ function reorder(aChildren, bChildren) {
                 // Match up the old keys
                 itemIndex = bKeys[aItem.key]
                 newChildren.push(bChildren[itemIndex])
-                sortOrder.push(itemIndex)
 
             } else {
                 // Remove old keyed items
-                // Moving an item to -1 deletes it. We have to keep
-                // track of items have been deleted as all items are shifted
-                // to the left after removal
                 itemIndex = i - deletedItems++
                 newChildren.push(null)
-                moves.push({
-                    from: itemIndex,
-                    to: -1
-                })
             }
         } else {
             // Match the item in a with the next free item in b
             if (freeIndex < freeCount) {
                 itemIndex = bFree[freeIndex++]
                 newChildren.push(bChildren[itemIndex])
-                sortOrder.push(itemIndex)
             } else {
                 // There are no free items in b to match with
                 // the free items in a, so the extra free nodes
                 // are deleted.
                 itemIndex = i - deletedItems++
                 newChildren.push(null)
-                moves.push({
-                    from: itemIndex,
-                    to: -1
-                })
             }
         }
     }
@@ -313,82 +298,97 @@ function reorder(aChildren, bChildren) {
                 // We are adding new items to the end and then sorting them
                 // in place. In future we should insert new items in place.
                 newChildren.push(newItem)
-                sortOrder.push(j);
             }
         } else if (j >= lastFreeIndex) {
             // Add any leftover non-keyed items
             newChildren.push(newItem)
-            sortOrder.push(j)
         }
     }
 
-    sortIndex(sortOrder, moves) // O(N^2) worst case
+    var simulate = newChildren.slice()
+    var simulateIndex = 0
+    var removes = []
+    var inserts = []
+    var simulateItem
+
+    for (var k = 0; k < bChildren.length;) {
+        var wantedItem = bChildren[k]
+        simulateItem = simulate[simulateIndex]
+
+        // remove items
+        while (simulateItem === null && simulate.length) {
+            removes.push(remove(simulate, simulateIndex, null))
+            simulateItem = simulate[simulateIndex]
+        }
+
+        if (!simulateItem || simulateItem.key !== wantedItem.key) {
+            // if we need a key in this position...
+            if (wantedItem.key) {
+                if (simulateItem && simulateItem.key) {
+                    // if an insert doesn't put this key in place, it needs to move
+                    if (bKeys[simulateItem.key] !== k + 1) {
+                        removes.push(remove(simulate, simulateIndex, simulateItem.key))
+                        simulateItem = simulate[simulateIndex]
+                        // if the remove didn't put the wanted item in place, we need to insert it
+                        if (!simulateItem || simulateItem.key !== wantedItem.key) {
+                            inserts.push({key: wantedItem.key, to: k})
+                        }
+                        // items are matching, so skip ahead
+                        else {
+                            simulateIndex++
+                        }
+                    }
+                    else {
+                        inserts.push({key: wantedItem.key, to: k})
+                    }
+                }
+                else {
+                    inserts.push({key: wantedItem.key, to: k})
+                }
+                k++
+            }
+            // a key in simulate has no matching wanted key, remove it
+            else if (simulateItem && simulateItem.key) {
+                removes.push(remove(simulate, simulateIndex, simulateItem.key))
+            }
+        }
+        else {
+            simulateIndex++
+            k++
+        }
+    }
+
+    // remove all the remaining nodes from simulate
+    while(simulateIndex < simulate.length) {
+        simulateItem = simulate[simulateIndex]
+        removes.push(remove(simulate, simulateIndex, simulateItem && simulateItem.key))
+    }
 
     // If the only moves we have are deletes then we can just
     // let the delete patch remove these items.
-    if (moves.length === deletedItems) {
+    if (removes.length === deletedItems && !inserts.length) {
         return {
             children: newChildren,
-            moves: []
+            moves: null
         }
     }
 
     return {
         children: newChildren,
-        moves: moves
-    }
-}
-
-function sortIndex(arr, moves) {
-    var arrLength = arr.length;
-
-    for (var i = 0; i < arrLength; i++) {
-        var item = arr[i];
-
-        if (item !== i) {
-            var desiredItemIndex = 0;
-            var swapDestination = 0;
-            var lessThanSearchHalt = item - i;
-            var lessThanSearchCount = 0;
-
-            for (var j = i + 1; j < arrLength; j++) {
-                var compareItem = arr[j];
-
-                if (compareItem < item) {
-                    lessThanSearchCount += 1;
-                    if (lessThanSearchCount === lessThanSearchHalt) {
-                        swapDestination = j + 1;
-                    }
-                }
-
-                if (compareItem === i) {
-                    desiredItemIndex = j;
-                }
-
-                if (desiredItemIndex > 0 && swapDestination > 0) {
-                    break;
-                }
-            }
-
-            if (swapDestination > desiredItemIndex + 1) {
-                moves.push(move(arr, i, swapDestination));
-                i--;
-            } else {
-                moves.push(move(arr, desiredItemIndex, i));
-            }
+        moves: {
+            removes: removes,
+            inserts: inserts
         }
     }
-
-    return moves
 }
 
-function move(array, from, to) {
-    array.splice(from < to ? to - 1 : to, 0, array.splice(from, 1)[0]);
+function remove(arr, index, key) {
+    arr.splice(index, 1)
 
     return {
-        from: from,
-        to: to
-    };
+        from: index,
+        key: key
+    }
 }
 
 function keyIndex(children) {


### PR DESCRIPTION
I have decided the reordering logic needs to be rewritten. I effectively take a bubble sort style approach to get the nodes in the correct shape. The offset counting is very error prone and difficult to debug so I've avoided that where possible.

As an extension to this, I would like to extend the capability of virtual-dom to insert at an index. Currently we use the `diff(null, newVnode)` feature to create the inserts. I would like to avoid inserting the items at the end and insert all new items at the correct index at creation time.

Having better insert semantics will remove all re-order overhead for inserts. We really need some benchmarks for this. I am interested to see how more or less efficient this becomes.