### PR TITLE
Rewrite reorder (part 2)

### DIFF
--- a/test/keys.js
+++ b/test/keys.js
@@ -7,6 +7,8 @@ var render = require("../create-element.js")
 
 var patchCount = require("./lib/patch-count.js")
 var assertEqualDom = require("./lib/assert-equal-dom.js")
+var nodesFromArray = require("./lib/nodes-from-array.js")
+var assertChildNodesFromArray = require("./lib/assert-childNodes-from-array.js")
 
 var VPatch = require("../vnode/vpatch.js")
 
@@ -766,49 +768,12 @@ function keyTest(itemsA, itemsB) {
     }
 }
 
-function assertChildNodesFromArray(assert, items, childNodes) {
-    // ensure that the output has the same number of nodes as required
-    assert.equal(childNodes.length, items.length)
-
-    for (var i = 0; i < items.length; i++) {
-        var key = items[i]
-        assert.equal(childNodes[i].id, key != null ? String(key) : 'no-key-' + i)
-    }
-}
-
 function childNodesArray(node) {
     var childNodes = []
     for (var i = 0; i < node.childNodes.length; i++) {
         childNodes.push(node.childNodes[i])
     }
     return childNodes
-}
-
-function nodesFromArray(array) {
-    var i =0
-    var children = []
-    var key
-    var properties
-
-    for(; i < array.length; i++) {
-        key = array[i]
-
-        if (key != null) {
-            properties = {
-                key: key,
-                id: String(key)
-            }
-        }
-        else {
-            properties = {
-                id: 'no-key-' + i
-            }
-        }
-
-        children.push(h('div', properties))
-    }
-
-    return h('div', children)
 }
 
 function getReorderPatch(patches) {

--- a/test/lib/assert-childNodes-from-array.js
+++ b/test/lib/assert-childNodes-from-array.js
@@ -1,0 +1,11 @@
+module.exports = assertChildNodesFromArray;
+
+function assertChildNodesFromArray(assert, items, childNodes) {
+    // ensure that the output has the same number of nodes as required
+    assert.equal(childNodes.length, items.length)
+
+    for (var i = 0; i < items.length; i++) {
+        var key = items[i]
+        assert.equal(childNodes[i].id, key != null ? String(key) : 'no-key-' + i)
+    }
+}

--- a/test/lib/nodes-from-array.js
+++ b/test/lib/nodes-from-array.js
@@ -1,0 +1,30 @@
+var h = require("../../h.js")
+
+module.exports = nodesFromArray
+
+function nodesFromArray(array) {
+    var i =0
+    var children = []
+    var key
+    var properties
+
+    for(; i < array.length; i++) {
+        key = array[i]
+
+        if (key != null) {
+            properties = {
+                key: key,
+                id: String(key)
+            }
+        }
+        else {
+            properties = {
+                id: 'no-key-' + i
+            }
+        }
+
+        children.push(h('div', properties, properties.id))
+    }
+
+    return h('div', children)
+}

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -134,11 +134,12 @@ function reorderChildren(domNode, moves) {
         domNode.removeChild(node)
     }
 
+    var length = childNodes.length
     for (var j = 0; j < moves.inserts.length; j++) {
         insert = moves.inserts[j]
         node = keyMap[insert.key]
         // this is the weirdest bug i've ever seen in webkit
-        domNode.insertBefore(node, insert.to >= childNodes.length ? null : childNodes[insert.to])
+        domNode.insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
     }
 }
 

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -120,20 +120,25 @@ function destroyWidget(domNode, w) {
 
 function reorderChildren(domNode, moves) {
     var childNodes = domNode.childNodes
+    var keyMap = {}
+    var node
+    var remove
+    var insert
 
-    for (var i = 0; i < moves.length; i++) {
-        var move = moves[i]
-        var from = move.from;
-        var to = move.to;
-
-        if (to >= 0) {
-            domNode.insertBefore(
-                childNodes[move.from],
-                childNodes[move.to]
-            )
-        } else {
-            domNode.removeChild(childNodes[from])
+    for (var i = 0; i < moves.removes.length; i++) {
+        remove = moves.removes[i]
+        node = childNodes[remove.from]
+        if (remove.key) {
+            keyMap[remove.key] = node
         }
+        domNode.removeChild(node)
+    }
+
+    for (var j = 0; j < moves.inserts.length; j++) {
+        insert = moves.inserts[j]
+        node = keyMap[insert.key]
+        // this is the weirdest bug i've ever seen in webkit
+        domNode.insertBefore(node, insert.to >= childNodes.length ? null : childNodes[insert.to])
     }
 }
 

--- a/vtree/diff.js
+++ b/vtree/diff.js
@@ -332,23 +332,20 @@ function reorder(aChildren, bChildren) {
                         // if the remove didn't put the wanted item in place, we need to insert it
                         if (!simulateItem || simulateItem.key !== wantedItem.key) {
                             inserts.push({key: wantedItem.key, to: k})
-                            k++
                         }
                         // items are matching, so skip ahead
                         else {
                             simulateIndex++
-                            k++
                         }
                     }
                     else {
                         inserts.push({key: wantedItem.key, to: k})
-                        k++
                     }
                 }
                 else {
                     inserts.push({key: wantedItem.key, to: k})
-                    k++
                 }
+                k++
             }
             // a key in simulate has no matching wanted key, remove it
             else if (simulateItem && simulateItem.key) {


### PR DESCRIPTION
@Matt-Esch this is some extra work on top of what you've done in #197.  please take the time to convince yourself that this is reasonable - i don't want to get this wrong again. i have relied on tests to prove this code as being correct but that's only as good as the tests themselves.

things of note:

* added some fuzzy testing - *please* check what i've done with the tests and make sure it's reasonable because i'm depending on these tests to make sure things are working.  there are some specific cases also included to exercise some corner cases and to make debugging/development easier.
* allowed for left-to-right moves when reordering.  this means that a change that moves one key from position 4 to position 7 is now just `[{ from: 4, to: 7}]` rather than `[{ from: 5, to: 4 }, { from: 6, to: 5 }, { from: 7, to: 6 }]`
* removed `while(!sorted)` loop which i think was previously making a reorder O(N<sup>3</sup>) (O(N) for the while loop * O(N) for the for loop * O(N) for searching for the node to move) and now it's O(N<sup>2</sup>) (O(N) for the for loop * O(N) for searching for the node to move)

this PR supersedes or fixes #191, #194, #197, #198

as i mentioned in #197, i think this change warrants a major version bump since the output format of a diff is changing in a backwards incompatible way (but i think it's definitely the right thing to do).  in doing that, let's look at what else may be something to address in a major version bump (e.g. stop allowing whitespace in selectors as discussed in #180)