### PR TITLE
Special case applying xmlns attributes.

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -187,6 +187,17 @@ test("node class name is applied correctly", function (assert) {
     assert.end()
 })
 
+test("node xmlns is applied correctly", function(assert){
+    var vdom = h("html", { xmlns: "http://www.w3.org/1999/xhtml" })
+    var dom = render(vdom)
+    assert.notOk(dom.id)
+    assert.notOk(dom.className)
+    assert.equal(dom.tagName, "HTML")
+    assert.equal(dom.getAttribute("xmlns"), "http://www.w3.org/1999/xhtml")
+    assert.equal(dom.childNodes.length, 0)
+    assert.end()
+})
+
 test("mixture of node/classname applied correctly", function (assert) {
     var vdom = h("#override.very", { id: "important", className: "pretty"})
     var dom = render(vdom)

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -20,7 +20,15 @@ function applyProperties(node, props, previous) {
             if (isObject(propValue)) {
                 patchObject(node, props, previous, propName, propValue);
             } else {
-                node[propName] = propValue
+                if (propName === 'xmlns') {
+                    if (node.namespace) {
+                        node.setAttributeNS(node.namespace, propName, propValue)
+                    } else {
+                        node.setAttribute(propName, propValue)
+                    }
+                } else {
+                    node[propName] = propValue
+                }
             }
         }
     }


### PR DESCRIPTION
Not all attributes can be set using the dot notation like you would for `className` and `id`.  In fact most attributes should be set using setAttribute and setAttributeNS. Using the dot notation incorrectly results in attributes being dropped when rendered as actual dom elements.

In our case we are working full HTML documents that must include an xmlns attribute. Performing any parsing and then rendering of vdom elements results in missing attributes as mentioned above.