### PR TITLE
Added link to original cmdline html2hyperscript utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ virtual-dom is heavily inspired by the inner workings of React by facebook. This
 
 * [html2hscript](https://github.com/twilson63/html2hscript) - Parse HTML into hyperscript
 * [html2hscript.herokuapp.com](http://html2hscript.herokuapp.com/) - Online Tool that converts html snippets to hyperscript
+* [html2hyperscript](https://github.com/unframework/html2hyperscript) - Original commandline utility to convert legacy HTML markup into hyperscript
 
 
 [1]: https://secure.travis-ci.org/Matt-Esch/virtual-dom.svg


### PR DESCRIPTION
Huge thanks to @twilson63 for making my original hacky `html2hyperscript` work as an online converter tool!

I figured I'd still add the link to the original repo (https://github.com/unframework/html2hyperscript) because it works on command line which may be helpful to some folks doing manual legacy conversion.