### PR TITLE
Removing trailing comma

### DIFF
--- a/vtree/diff.js
+++ b/vtree/diff.js
@@ -408,7 +408,7 @@ function keyIndex(children) {
 
     return {
         keys: keys,     // A hash of key name to index
-        free: free,     // An array of unkeyed item indices
+        free: free      // An array of unkeyed item indices
     }
 }
 


### PR DESCRIPTION
Removing a trailing comma as it might lead to parsing errors in IE8.