### PR TITLE
Allows hooks to also receive a reference of the vpatch instance.

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,10 +4,19 @@ Hooks are functions that execute after turning a VNode into an Element. They are
 Will Work
 ```javascript
 var Hook = function(){}
-Hook.prototype.hook = function(node, propertyName, previousValue) { 
+Hook.prototype.hook = function(node, propertyName, previousValue, vPatch) {
   console.log("Hello, World")
 }
-createElement(h('div', { "my-hook": new Hook() }))
+Hook.prototype.unhook = function(node, propertyName, nextValue, vPatch) {
+  console.log("Bye, World")
+}
+var first = h('div', { "my-hook": new Hook() })
+var second = h('div')
+
+var elem = createElement(h('div', first))
+var patches = diff(first, second)
+var elem = patch(elem, patches)
+
 ```
 
 Won't Work
@@ -19,7 +28,7 @@ createElement(h('div', { "my-hook": hook }))
 ## Arguments
 Your hook function will be given the following arguments
 
-**node**  
+**node**
 The Element generated from the VNode.
 
 ```javascript
@@ -31,20 +40,34 @@ createElement(h('div', { "my-hook": new Hook() }))
 // logs "type: HTMLDivElement"
 ```
 
-**propertyName**  
+**propertyName**
 String, key of the property this hook was assigned from.
 
 ```javascript
 var Hook = function(){}
-Hook.prototype.hook = function(node, propertyName, previousValue) { 
+Hook.prototype.hook = function(node, propertyName, previousValue) {
   console.log("name: " + propertyName)
 }
 createElement(h('div', { "my-hook": new Hook() }))
 // logs "name: my-hook"
 ```
 
-**previousValue** *(optional)*  
+**previousValue** *(optional)*
 If this node is having just its properties changed during a patch, it will receive the value that was previously assigned to the key. Otherwise, this argument will be undefined.
+
+**nextValue** *(optional)*
+If this node is having just its properties changed during a patch, it will receive the new value which are going to be assigned. Otherwise, this argument will be undefined.
+
+**vPatch**
+It contains a vPatch instance which contain the following values:
+
+```javascript
+{
+    type: <the patch type>
+    vNode: <the node on which the patch is going to be applied>
+    patch: <the new properties to apply>
+}
+```
 
 ## Other Examples
 [virtual-hyperscript](https://github.com/Matt-Esch/virtual-dom/tree/master/virtual-hyperscript) uses hooks for several things, including setting up events and returning focus to input elements after a render. You can view these hooks in the [virtual-hyperscript/hooks](https://github.com/Matt-Esch/virtual-dom/tree/master/virtual-hyperscript/hooks) folder.

--- a/vdom/create-element.js
+++ b/vdom/create-element.js
@@ -1,7 +1,7 @@
 var document = require("global/document")
 
 var applyProperties = require("./apply-properties")
-
+var VPatch = require("../vnode/vpatch")
 var isVNode = require("../vnode/is-vnode.js")
 var isVText = require("../vnode/is-vtext.js")
 var isWidget = require("../vnode/is-widget.js")
@@ -31,7 +31,7 @@ function createElement(vnode, opts) {
         doc.createElementNS(vnode.namespace, vnode.tagName)
 
     var props = vnode.properties
-    applyProperties(node, props)
+    applyProperties(node, props, undefined, new VPatch(VPatch.VNODE, vnode, props))
 
     var children = vnode.children
 

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -28,7 +28,7 @@ function applyPatch(vpatch, domNode, renderOptions) {
             reorderChildren(domNode, patch)
             return domNode
         case VPatch.PROPS:
-            applyProperties(domNode, patch, vNode.properties)
+            applyProperties(domNode, patch, vNode.properties, vpatch)
             return domNode
         case VPatch.THUNK:
             return replaceRoot(domNode,


### PR DESCRIPTION
This PR allows hooks to also receive a reference of the vpatch instance.
When a node is created, there was no easy way to retreive all the properties used for creating the node.
This would be particularly useful when the vdom is automatically generated from some html template. This way, the hook system can also be used in a wider range.