### PR TITLE
Fixes a circular reference infinite loop when runned with `run-browser.`

### DIFF
--- a/test/lib/assert-equal-dom.js
+++ b/test/lib/assert-equal-dom.js
@@ -22,6 +22,8 @@ function areEqual(a, b) {
             key !== "self" &&
             key !== "outerHTML" &&
             key !== "innerHTML" &&
+            key !== "spellcheck" &&
+            key !== "bind" &&
             "" + parseInt(key, 10) !== key
         ) {
             if (key === "ownerDocument") {


### PR DESCRIPTION
I don't now if it's related to my config but looks like `'assertEqualDom()`' run into an infinite loop when trying to run tests locally with:
```
run-browser test/index.js -b | tap-spec
```

Does anybody experienced the same issue ?