### PR TITLE
Allow minimal `vNode`

### DIFF
--- a/vdom/create-element.js
+++ b/vdom/create-element.js
@@ -26,6 +26,7 @@ function createElement(vnode, opts) {
         return null
     }
 
+    var tagName = vnode.tagName || "span"
     var node = (vnode.namespace === null) ?
         doc.createElement(vnode.tagName) :
         doc.createElementNS(vnode.namespace, vnode.tagName)
@@ -33,7 +34,7 @@ function createElement(vnode, opts) {
     var props = vnode.properties
     applyProperties(node, props)
 
-    var children = vnode.children
+    var children = vnode.children || []
 
     for (var i = 0; i < children.length; i++) {
         var childNode = createElement(children[i], opts)

--- a/vdom/create-element.js
+++ b/vdom/create-element.js
@@ -26,7 +26,7 @@ function createElement(vnode, opts) {
         return null
     }
 
-    var tagName = vnode.tagName || "span"
+    var tagName = vnode.tagName || "div"
     var node = (vnode.namespace === null) ?
         doc.createElement(vnode.tagName) :
         doc.createElementNS(vnode.namespace, vnode.tagName)


### PR DESCRIPTION
Let’s make the API more forgiving to other implementations :)

**Why:** I’m working on a very light, partial implementation of `virtual-dom`. I want to use it in a browser-facing library, so I can’t afford bundling 20-odd kB minified code. But I want to keep my lib compatible with `virtual-dom` to make it extensible and plugin-friendly – `virtual-dom` seems to be becoming a standard.