### PR TITLE
Remove redundant code branch in diffProps

### DIFF
--- a/vtree/diff-props.js
+++ b/vtree/diff-props.js
@@ -7,11 +7,6 @@ function diffProps(a, b) {
     var diff
 
     for (var aKey in a) {
-        if (!(aKey in b)) {
-            diff = diff || {}
-            diff[aKey] = undefined
-        }
-
         var aValue = a[aKey]
         var bValue = b[aKey]
 

--- a/vtree/test/diff-props.js
+++ b/vtree/test/diff-props.js
@@ -1,20 +1,58 @@
 var test = require("tape")
 var diffProps = require("../diff-props")
 
-test("add attributes to empty attributes", function (assert) {
-    var propsA = {
-      attributes : {}
-    }
-    var propsB = {
-        attributes : {
-            class : "standard",
-            "e-text" : "custom"
-        }
-    }
+test("adds new properties", function(assert) {
+    var propsA = {}
+    var propsB = {id: 'element-id', className: 'the-class'}
 
-    var diff = diffProps(propsA,propsB)
-    assert.equal(diff.attributes.class, "standard")
-    assert.equal(diff.attributes["e-text"], "custom")
+    var diff = diffProps(propsA, propsB)
+    assert.deepEqual(diff, {
+        id: 'element-id',
+        className: 'the-class'
+    })
+
+    assert.end()
+})
+
+test("removes missing properties", function(assert) {
+    var propsA = {id: 'element-id', className: 'the-class'}
+    var propsB = {}
+
+    var diff = diffProps(propsA, propsB)
+    assert.deepEqual(diff, {
+        id: undefined,
+        className: undefined
+    })
+
+    assert.end()
+})
+
+test("recursively adds new properties", function(assert) {
+    var propsA = {attributes: {}}
+    var propsB = {attributes: {'data-custom': 'custom', class: 'the-class'}}
+
+    var diff = diffProps(propsA, propsB)
+    assert.deepEqual(diff, {
+        attributes: {
+            'data-custom': 'custom',
+            class: 'the-class'
+        }
+    })
+
+    assert.end()
+})
+
+test("recursively removes missing properties", function(assert) {
+    var propsA = {attributes: {'data-custom': 'custom', class: 'the-class'}}
+    var propsB = {attributes: {}}
+
+    var diff = diffProps(propsA, propsB)
+    assert.deepEqual(diff, {
+        attributes: {
+            'data-custom': undefined,
+            class: undefined
+        }
+    })
 
     assert.end()
 })


### PR DESCRIPTION
I guess that the original idea was to put a `continue` statement
to the bottom of that `if` branch, as in:

```javascript
if (!(aKey in b)) {
    diff = diff || {}
    diff[aKey] = undefined
    continue
}
```

While that would be more performant in the case where the `aKey` property
is missing from `b`, it is slower in the more common case where the `aKey`
property is still present in `b`, so I think it makes sense to just remove
the `if` branch altogether.

I created a jsperf case comparing using `continue` with removing the `if` branch for when:
* all properties of `a` are removed from `b`: http://jsperf.com/virtual-dom-diffprops-with-emptied-props
* all propetires of `a` remain identical in `b`: http://jsperf.com/virtual-dom-diffprops-with-identical-props