### PR TITLE
Removing noProperties and noChildren fixed variables in vnode.js

### DIFF
--- a/vnode/vnode.js
+++ b/vnode/vnode.js
@@ -6,13 +6,10 @@ var isVHook = require("./is-vhook")
 
 module.exports = VirtualNode
 
-var noProperties = {}
-var noChildren = []
-
 function VirtualNode(tagName, properties, children, key, namespace) {
     this.tagName = tagName
-    this.properties = properties || noProperties
-    this.children = children || noChildren
+    this.properties = properties || {}
+    this.children = children || []
     this.key = key != null ? String(key) : undefined
     this.namespace = (typeof namespace === "string") ? namespace : null
 


### PR DESCRIPTION
In vnode.js properties and children must be create allways new instance for all of nodes. Using noProperties and noChildren variables may cause instance problems.