### PR TITLE
Add type properties to hooks

### DIFF
--- a/virtual-hyperscript/hooks/ev-hook.js
+++ b/virtual-hyperscript/hooks/ev-hook.js
@@ -25,3 +25,5 @@ EvHook.prototype.unhook = function(node, propertyName) {
 
     es[propName] = undefined;
 };
+
+EvHook.prototype.type = 'EvHook';

--- a/virtual-hyperscript/hooks/focus-hook.js
+++ b/virtual-hyperscript/hooks/focus-hook.js
@@ -18,3 +18,5 @@ MutableFocusHook.prototype.hook = function (node) {
         }
     });
 };
+
+MutableFocusHook.prototype.type = 'MutableFocusHook';

--- a/virtual-hyperscript/hooks/soft-set-hook.js
+++ b/virtual-hyperscript/hooks/soft-set-hook.js
@@ -15,3 +15,5 @@ SoftSetHook.prototype.hook = function (node, propertyName) {
         node[propertyName] = this.value;
     }
 };
+
+SoftSetHook.prototype.type = 'SoftSetHook';


### PR DESCRIPTION
`AttributeHook` has a `type` property available on it's prototype but the other hooks don't. Providing the `type` property helps other libraries parse vdom, such as [this discussion in vdom-to-html](https://github.com/nthtran/vdom-to-html/issues/13). At the moment there is no easy way to convert a hook to html. Using `instanceof` requires the same npm package which isn't always possible.

This PR adds a type property to `ev-hook`, `focus-hook` and `soft-set-hook`.

If it makes sense it might also be nice to add corresponding `is-ev-hook`, `is-focus-hook` and `is-soft-set-hook` files in [vnode](https://github.com/Matt-Esch/virtual-dom/tree/master/vnode).

Thoughts?
