### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,7 @@
     "tape": "^4.0.0",
     "zuul": "^2.1.1"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Matt-Esch/virtual-dom/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "node ./test/index.js | tap-spec",
     "dot": "node ./test/index.js | tap-dot",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/