### PR TITLE
Expose svg on global export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var diff = require("./diff.js")
 var patch = require("./patch.js")
 var h = require("./h.js")
+var svg = require("./svg.js")
 var create = require("./create-element.js")
 var VNode = require('./vnode/vnode.js')
 var VText = require('./vnode/vtext.js')
@@ -9,6 +10,7 @@ module.exports = {
     diff: diff,
     patch: patch,
     h: h,
+    svg: svg,
     create: create,
     VNode: VNode,
     VText: VText

--- a/svg.js
+++ b/svg.js
@@ -1,0 +1,3 @@
+var svg = require("./virtual-hyperscript/svg.js")
+
+module.exports = svg


### PR DESCRIPTION
2 good things about exposing `svg` explicitly:

1. make it clear `virtual-dom` consider it a public api.
2. make new users aware of this api.

We use `svg` extensively for our svg icon rendering, would be nice to not having to include them using full path like `virtual-dom/virtual-hyperscript/svg`.

PS: I tried to find a good place to add tests. but there doesn't seem to be a test for `index.js`, is `test/main` an ok place?