### PR TITLE
Why doesn't markup support numbers ?

### DIFF
--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -63,6 +63,8 @@ function h(tagName, properties, children) {
 function addChild(c, childNodes, tag, props) {
     if (typeof c === 'string') {
         childNodes.push(new VText(c));
+    } else if (typeof c === 'number') {
+        childNodes.push(new VText(String(c)));
     } else if (isChild(c)) {
         childNodes.push(c);
     } else if (isArray(c)) {


### PR DESCRIPTION
This construct h('td', null, [0]) gives error:
Uncaught Error: Unexpected virtual child passed to h().
Expected a VNode / Vthunk / VWidget / string but: got 0

Seems easy to fix: