### PR TITLE
make class shorthand work with svg element

### DIFF
--- a/virtual-hyperscript/svg.js
+++ b/virtual-hyperscript/svg.js
@@ -3,7 +3,7 @@
 var isArray = require('x-is-array');
 
 var h = require('./index.js');
-
+var parseTag = require('./parse-tag.js');
 
 var SVGAttributeNamespace = require('./svg-attribute-namespace');
 var attributeHook = require('./hooks/attribute-hook');
@@ -23,10 +23,19 @@ function svg(tagName, properties, children) {
     // set namespace for svg
     properties.namespace = SVG_NAMESPACE;
 
+    // parse tag now to support className
+    var tag = parseTag(tagName, properties);
+
     var attributes = properties.attributes || (properties.attributes = {});
 
     for (var key in properties) {
         if (!properties.hasOwnProperty(key)) {
+            continue;
+        }
+
+        if (key === 'className') {
+            attributes['class'] = properties[key];
+            properties[key] = undefined;
             continue;
         }
 
@@ -54,7 +63,7 @@ function svg(tagName, properties, children) {
         properties[key] = undefined
     }
 
-    return h(tagName, properties, children);
+    return h(tag, properties, children);
 }
 
 function isChildren(x) {

--- a/virtual-hyperscript/test/svg.js
+++ b/virtual-hyperscript/test/svg.js
@@ -28,7 +28,7 @@ test("svg with properties", function (assert) {
 })
 
 test("svg properties are set", function (assert) {
-    var node = svg("circle.test", {
+    var node = svg("circle.class#id", {
         style: {
             border: "1px solid #000"
         },
@@ -37,6 +37,10 @@ test("svg properties are set", function (assert) {
 
     assert.strictEqual(node.properties.attributes.width, "40px")
     assert.strictEqual(node.properties.width, undefined)
+    assert.strictEqual(node.properties.attributes.class, "class")
+    assert.strictEqual(node.properties.class, undefined)
+    assert.strictEqual(node.properties.attributes.id, "id")
+    assert.strictEqual(node.properties.id, undefined)
     assert.strictEqual(
         node.properties.style.border,
         safeStyle("boder", "1px solid #000")


### PR DESCRIPTION
As commented here: https://github.com/Matt-Esch/virtual-dom/issues/262#issuecomment-111843921

If we don't parse tag in `svg` before handover to `h`, we won't be able to use `tag.class` shorthand because svg only support `class` property, not `className` property.

But this is kind a hack, I hope to see a better way.