### PR TITLE
Add support to virtual-hyperscript for false value in children

### DIFF
--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -69,7 +69,7 @@ function addChild(c, childNodes, tag, props) {
         for (var i = 0; i < c.length; i++) {
             addChild(c[i], childNodes, tag, props);
         }
-    } else if (c === null || c === undefined) {
+    } else if (c === null || c === undefined || c === false) {
         return;
     } else {
         throw UnexpectedVirtualElement({

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -111,6 +111,16 @@ test("h with undefined", function (assert) {
     assert.end()
 })
 
+test("h with false", function (assert) {
+    var node = h("div", false)
+    var node2 = h("div", [false])
+
+    assert.equal(node.children.length, 0)
+    assert.equal(node2.children.length, 0)
+
+    assert.end()
+})
+
 test("h with foreign object", function (assert) {
     var errorSingleChild
 


### PR DESCRIPTION
An error of UnexpectedVirtualElement is being thrown when using [jsx-transform](https://github.com/alexmingoia/jsx-transform/) with the following use-case.

```<div>{x > 1 && 'You have more than one item'}</div>``` [Reference](https://facebook.github.io/react/tips/false-in-jsx.html)

It's being transformed to the following:

```h("h1", null, [ false ])```

The attached pull request would ignore any false values in addChild of virtual-hyperscript