### PR TITLE
coerce numbers to strings in hyperscript

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ require("./keys.js")
 require("./thunk.js")
 require("./style.js")
 require("./attributes")
+require("./non-string.js")
 
 require("../vdom/test/")
 require("../vtree/test/")

--- a/test/non-string.js
+++ b/test/non-string.js
@@ -1,0 +1,14 @@
+var test = require("tape")
+var h = require("../h.js")
+var diff = require("../diff.js")
+var patch = require("../patch.js")
+var createElement = require("../create-element.js")
+
+test("coerce numbers to strings in children array", function (assert) {
+    var leftNode = h("div", [ "clicked ", 1336, " times" ])
+    var rightNode = h("div", [ "clicked ", 1337, " times" ])
+    var rootNode = createElement(leftNode)
+    var newRoot = patch(rootNode, diff(leftNode, rightNode))
+    assert.equal(newRoot.toString(), '<div>clicked 1337 times</div>')
+    assert.end()
+})

--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -61,8 +61,10 @@ function h(tagName, properties, children) {
 }
 
 function addChild(c, childNodes, tag, props) {
-    if (typeof c === 'string' || typeof c === 'number') {
+    if (typeof c === 'string') {
         childNodes.push(new VText(c));
+    } else if (typeof c === 'number') {
+        childNodes.push(new VText(String(c)));
     } else if (isChild(c)) {
         childNodes.push(c);
     } else if (isArray(c)) {

--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -61,7 +61,7 @@ function h(tagName, properties, children) {
 }
 
 function addChild(c, childNodes, tag, props) {
-    if (typeof c === 'string') {
+    if (typeof c === 'string' || typeof c === 'number') {
         childNodes.push(new VText(c));
     } else if (isChild(c)) {
         childNodes.push(c);


### PR DESCRIPTION
Several times I've run into errors when I accidentally use a number:

``` js
var h = require('virtual-dom/h');
var create = require('virtual-dom/create-element');
var node = h('div', [ 'clicked ', 1337, ' times' ]);
console.log(create(node).toString());
```

Currently, the above code will cause this very unfriendly error:

```
tmp/node_modules/virtual-dom/virtual-hyperscript/index.js:75
        throw UnexpectedVirtualElement({
              ^
Error: Unexpected virtual child passed to h().
Expected a VNode / Vthunk / VWidget / string but:
got:
1337.
The parent vnode is:
{
    "tagName": "DIV",
    "properties": {}
}
    at UnexpectedVirtualElement (/tmp/node_modules/virtual-dom/virtual-hyperscript/index.js:111:15)
    at addChild (/tmp/node_modules/virtual-dom/virtual-hyperscript/index.js:75:15)
    at addChild (/tmp/node_modules/virtual-dom/virtual-hyperscript/index.js:70:13)
    at h (/tmp/node_modules/virtual-dom/virtual-hyperscript/index.js:56:9)
    at Object.<anonymous> (/tmp/main.js:3:12)
    at Module._compile (module.js:431:26)
    at Object.Module._extensions..js (module.js:449:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:472:10)
```

But with this patch, numbers are coerced to strings for text nodes:

```
<div>clicked 1337 times</div>
```