### PR TITLE
recursive patch call

### DIFF
--- a/vdom/patch.js
+++ b/vdom/patch.js
@@ -8,7 +8,9 @@ module.exports = patch
 
 function patch(rootNode, patches, renderOptions) {
     renderOptions = renderOptions || {}
-    renderOptions.patch = renderOptions.patch || patchRecursive
+    renderOptions.patch = renderOptions.patch && renderOptions.patch !== patch
+        ? renderOptions.patch
+        : patchRecursive
     renderOptions.render = renderOptions.render || render
 
     return renderOptions.patch(rootNode, patches, renderOptions)


### PR DESCRIPTION
If `renderOptions.patch === module.exports` then `patch` is being called recursively.
For example in mercury/index.js -> `main()` call