### PR TITLE
WIP - Polymer support - DO NOT MERGE

### DIFF
--- a/dist/virtual-dom.js
+++ b/dist/virtual-dom.js
@@ -254,6 +254,8 @@ module.exports = patch
 var isObject = require("is-object")
 var isHook = require("../vnode/is-vhook.js")
 
+var Dom = require("../polymer-dom.js")
+
 module.exports = applyProperties
 
 function applyProperties(node, props, previous) {
@@ -286,7 +288,7 @@ function removeProperty(node, propName, propValue, previous) {
         if (!isHook(previousValue)) {
             if (propName === "attributes") {
                 for (var attrName in previousValue) {
-                    node.removeAttribute(attrName)
+                    Dom(node).removeAttribute(attrName)
                 }
             } else if (propName === "style") {
                 for (var i in previousValue) {
@@ -312,9 +314,9 @@ function patchObject(node, props, previous, propName, propValue) {
             var attrValue = propValue[attrName]
 
             if (attrValue === undefined) {
-                node.removeAttribute(attrName)
+                Dom(node).removeAttribute(attrName)
             } else {
-                node.setAttribute(attrName, attrValue)
+                Dom(node).setAttribute(attrName, attrValue)
             }
         }
 
@@ -359,6 +361,8 @@ var isVText = require("../vnode/is-vtext.js")
 var isWidget = require("../vnode/is-widget.js")
 var handleThunk = require("../vnode/handle-thunk.js")
 
+var Dom = require("../polymer-dom.js")
+
 module.exports = createElement
 
 function createElement(vnode, opts) {
@@ -390,7 +394,7 @@ function createElement(vnode, opts) {
     for (var i = 0; i < children.length; i++) {
         var childNode = createElement(children[i], opts)
         if (childNode) {
-            node.appendChild(childNode)
+            Dom(node).appendChild(childNode)
         }
     }
 
@@ -405,6 +409,8 @@ function createElement(vnode, opts) {
 // interest.
 
 var noChild = {}
+
+var Dom = require("../polymer-dom.js")
 
 module.exports = domIndex
 
@@ -430,7 +436,7 @@ function recurse(rootNode, tree, indices, nodes, rootIndex) {
 
         if (vChildren) {
 
-            var childNodes = rootNode.childNodes
+            var childNodes = Dom(rootNode).childNodes
 
             for (var i = 0; i < tree.children.length; i++) {
                 rootIndex += 1
@@ -492,6 +498,8 @@ var VPatch = require("../vnode/vpatch.js")
 
 var updateWidget = require("./update-widget")
 
+var Dom = require("../polymer-dom.js")
+
 module.exports = applyPatch
 
 function applyPatch(vpatch, domNode, renderOptions) {
@@ -525,10 +533,10 @@ function applyPatch(vpatch, domNode, renderOptions) {
 }
 
 function removeNode(domNode, vNode) {
-    var parentNode = domNode.parentNode
+    var parentNode = Dom(domNode).parentNode
 
     if (parentNode) {
-        parentNode.removeChild(domNode)
+        Dom(parentNode).removeChild(domNode)
     }
 
     destroyWidget(domNode, vNode);
@@ -540,7 +548,7 @@ function insertNode(parentNode, vNode, renderOptions) {
     var newNode = renderOptions.render(vNode, renderOptions)
 
     if (parentNode) {
-        parentNode.appendChild(newNode)
+        Dom(parentNode).appendChild(newNode)
     }
 
     return parentNode
@@ -553,7 +561,7 @@ function stringPatch(domNode, leftVNode, vText, renderOptions) {
         domNode.replaceData(0, domNode.length, vText.text)
         newNode = domNode
     } else {
-        var parentNode = domNode.parentNode
+        var parentNode = Dom(domNode).parentNode
         newNode = renderOptions.render(vText, renderOptions)
 
         if (parentNode && newNode !== domNode) {
@@ -574,7 +582,7 @@ function widgetPatch(domNode, leftVNode, widget, renderOptions) {
         newNode = renderOptions.render(widget, renderOptions)
     }
 
-    var parentNode = domNode.parentNode
+    var parentNode = Dom(domNode).parentNode
 
     if (parentNode && newNode !== domNode) {
         parentNode.replaceChild(newNode, domNode)
@@ -588,7 +596,7 @@ function widgetPatch(domNode, leftVNode, widget, renderOptions) {
 }
 
 function vNodePatch(domNode, leftVNode, vNode, renderOptions) {
-    var parentNode = domNode.parentNode
+    var parentNode = Dom(domNode).parentNode
     var newNode = renderOptions.render(vNode, renderOptions)
 
     if (parentNode && newNode !== domNode) {
@@ -605,7 +613,7 @@ function destroyWidget(domNode, w) {
 }
 
 function reorderChildren(domNode, moves) {
-    var childNodes = domNode.childNodes
+    var childNodes = Dom(domNode).childNodes
     var keyMap = {}
     var node
     var remove
@@ -617,7 +625,7 @@ function reorderChildren(domNode, moves) {
         if (remove.key) {
             keyMap[remove.key] = node
         }
-        domNode.removeChild(node)
+        Dom(domNode).removeChild(node)
     }
 
     var length = childNodes.length
@@ -625,13 +633,13 @@ function reorderChildren(domNode, moves) {
         insert = moves.inserts[j]
         node = keyMap[insert.key]
         // this is the weirdest bug i've ever seen in webkit
-        domNode.insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
+        Dom(domNode).insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
     }
 }
 
 function replaceRoot(oldRoot, newRoot) {
-    if (oldRoot && newRoot && oldRoot !== newRoot && oldRoot.parentNode) {
-        oldRoot.parentNode.replaceChild(newRoot, oldRoot)
+    if (oldRoot && newRoot && oldRoot !== newRoot && Dom(oldRoot).parentNode) {
+        Dom(oldRoot).parentNode.replaceChild(newRoot, oldRoot)
     }
 
     return newRoot;

--- a/polymer-dom.js
+++ b/polymer-dom.js
@@ -1,0 +1,13 @@
+// Perform dom manipulation through Polymer.dom if available
+
+var Dom;
+
+if(Polymer && typeof Polymer.dom === 'function') {
+    // Bind to Polymer.dom
+    Dom = Polymer.dom.bind(Polymer);
+} else {
+    // Identity function
+    Dom = function(x) {return x;};
+}
+
+module.exports = Dom;

--- a/test/keys.js
+++ b/test/keys.js
@@ -12,6 +12,8 @@ var assertChildNodesFromArray = require("./lib/assert-childNodes-from-array.js")
 
 var VPatch = require("../vnode/vpatch.js")
 
+var Dom = require("../polymer-dom.js")
+
 test("keys get reordered", function (assert) {
     var leftNode = nodesFromArray(["1", "2", "3", "4", "test", "6", "good", "7"])
     var rightNode = nodesFromArray(["7", "4", "3", "2", "6", "test", "good", "1"])
@@ -19,8 +21,8 @@ test("keys get reordered", function (assert) {
     var rootNode = render(leftNode)
 
     var childNodes = []
-    for (var i = 0; i < rootNode.childNodes.length; i++) {
-        childNodes.push(rootNode.childNodes[i])
+    for (var i = 0; i < Dom(rootNode).childNodes.length; i++) {
+        childNodes.push(Dom(rootNode).childNodes[i])
     }
 
     var patches = diff(leftNode, rightNode)
@@ -45,16 +47,16 @@ test("keys get reordered", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, rootNode.childNodes.length)
+    assert.equal(Dom(newRoot).childNodes.length, Dom(rootNode).childNodes.length)
 
-    assert.equal(newRoot.childNodes[7], childNodes[0])
-    assert.equal(newRoot.childNodes[3], childNodes[1])
-    assert.equal(newRoot.childNodes[2], childNodes[2])
-    assert.equal(newRoot.childNodes[1], childNodes[3])
-    assert.equal(newRoot.childNodes[5], childNodes[4])
-    assert.equal(newRoot.childNodes[4], childNodes[5])
-    assert.equal(newRoot.childNodes[6], childNodes[6])
-    assert.equal(newRoot.childNodes[0], childNodes[7])
+    assert.equal(Dom(newRoot).childNodes[7], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[3], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[2], childNodes[2])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[3])
+    assert.equal(Dom(newRoot).childNodes[5], childNodes[4])
+    assert.equal(Dom(newRoot).childNodes[4], childNodes[5])
+    assert.equal(Dom(newRoot).childNodes[6], childNodes[6])
+    assert.equal(Dom(newRoot).childNodes[0], childNodes[7])
     assert.end()
 })
 
@@ -94,16 +96,16 @@ test("mix keys without keys", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, rootNode.childNodes.length)
+    assert.equal(Dom(newRoot).childNodes.length, Dom(rootNode).childNodes.length)
 
-    assert.equal(newRoot.childNodes[0], childNodes[1])
-    assert.equal(newRoot.childNodes[1], childNodes[2])
-    assert.equal(newRoot.childNodes[2], childNodes[3])
-    assert.equal(newRoot.childNodes[3], childNodes[4])
-    assert.equal(newRoot.childNodes[4], childNodes[5])
-    assert.equal(newRoot.childNodes[5], childNodes[6])
-    assert.equal(newRoot.childNodes[6], childNodes[7])
-    assert.equal(newRoot.childNodes[7], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[0], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[2])
+    assert.equal(Dom(newRoot).childNodes[2], childNodes[3])
+    assert.equal(Dom(newRoot).childNodes[3], childNodes[4])
+    assert.equal(Dom(newRoot).childNodes[4], childNodes[5])
+    assert.equal(Dom(newRoot).childNodes[5], childNodes[6])
+    assert.equal(Dom(newRoot).childNodes[6], childNodes[7])
+    assert.equal(Dom(newRoot).childNodes[7], childNodes[0])
     assert.end()
 })
 
@@ -129,9 +131,9 @@ test("avoid unnecessary reordering", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes[0], childNodes[0])
-    assert.equal(newRoot.childNodes[1], childNodes[1])
-    assert.equal(newRoot.childNodes[2], childNodes[2])
+    assert.equal(Dom(newRoot).childNodes[0], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[2], childNodes[2])
     assert.end()
 })
 
@@ -161,8 +163,8 @@ test("missing key gets replaced", function (assert) {
     var rootNode = render(leftNode)
 
     var childNodes = []
-    for (var i = 0; i < rootNode.childNodes.length; i++) {
-        childNodes.push(rootNode.childNodes[i])
+    for (var i = 0; i < Dom(rootNode).childNodes.length; i++) {
+        childNodes.push(Dom(rootNode).childNodes[i])
     }
 
     var patches = diff(leftNode, rightNode)
@@ -171,16 +173,16 @@ test("missing key gets replaced", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, rootNode.childNodes.length)
+    assert.equal(Dom(newRoot).childNodes.length, Dom(rootNode).childNodes.length)
 
-    assert.notEqual(newRoot.childNodes[0], childNodes[0])
-    assert.equal(newRoot.childNodes[1], childNodes[1])
-    assert.equal(newRoot.childNodes[2], childNodes[2])
-    assert.equal(newRoot.childNodes[3], childNodes[3])
-    assert.equal(newRoot.childNodes[4], childNodes[4])
-    assert.equal(newRoot.childNodes[5], childNodes[5])
-    assert.equal(newRoot.childNodes[6], childNodes[6])
-    assert.equal(newRoot.childNodes[7], childNodes[7])
+    assert.notEqual(Dom(newRoot).childNodes[0], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[2], childNodes[2])
+    assert.equal(Dom(newRoot).childNodes[3], childNodes[3])
+    assert.equal(Dom(newRoot).childNodes[4], childNodes[4])
+    assert.equal(Dom(newRoot).childNodes[5], childNodes[5])
+    assert.equal(Dom(newRoot).childNodes[6], childNodes[6])
+    assert.equal(Dom(newRoot).childNodes[7], childNodes[7])
     assert.end()
 })
 
@@ -224,11 +226,11 @@ test("widgets can be keyed", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, rootNode.childNodes.length)
+    assert.equal(Dom(newRoot).childNodes.length, Dom(rootNode).childNodes.length)
 
-    assertEqualDom(assert, newRoot.childNodes[0], childNodes[2])
-    assertEqualDom(assert, newRoot.childNodes[1], childNodes[1])
-    assertEqualDom(assert, newRoot.childNodes[2], childNodes[0])
+    assertEqualDom(assert, Dom(newRoot).childNodes[0], childNodes[2])
+    assertEqualDom(assert, Dom(newRoot).childNodes[1], childNodes[1])
+    assertEqualDom(assert, Dom(newRoot).childNodes[2], childNodes[0])
     assert.end()
 })
 
@@ -254,10 +256,10 @@ test("delete key at the start", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 2)
+    assert.equal(Dom(newRoot).childNodes.length, 2)
 
-    assert.equal(newRoot.childNodes[0], childNodes[1])
-    assert.equal(newRoot.childNodes[1], childNodes[2])
+    assert.equal(Dom(newRoot).childNodes[0], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[2])
     assert.end()
 })
 
@@ -282,10 +284,10 @@ test("add key to start", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 3)
+    assert.equal(Dom(newRoot).childNodes.length, 3)
 
-    assert.equal(newRoot.childNodes[1], childNodes[0])
-    assert.equal(newRoot.childNodes[2], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[2], childNodes[1])
     assert.end()
 })
 
@@ -311,10 +313,10 @@ test("delete key at the end", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 2)
+    assert.equal(Dom(newRoot).childNodes.length, 2)
 
-    assert.equal(newRoot.childNodes[0], childNodes[0])
-    assert.equal(newRoot.childNodes[1], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[0], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[1])
     assert.end()
 })
 
@@ -339,10 +341,10 @@ test("add key to end", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 3)
+    assert.equal(Dom(newRoot).childNodes.length, 3)
 
-    assert.equal(newRoot.childNodes[0], childNodes[0])
-    assert.equal(newRoot.childNodes[1], childNodes[1])
+    assert.equal(Dom(newRoot).childNodes[0], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[1])
     assert.end()
 })
 
@@ -370,11 +372,11 @@ test("add to end and delete from center & reverse", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 4)
+    assert.equal(Dom(newRoot).childNodes.length, 4)
 
-    assert.equal(newRoot.childNodes[1], childNodes[3])
-    assert.equal(newRoot.childNodes[2], childNodes[2])
-    assert.equal(newRoot.childNodes[3], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[1], childNodes[3])
+    assert.equal(Dom(newRoot).childNodes[2], childNodes[2])
+    assert.equal(Dom(newRoot).childNodes[3], childNodes[0])
     assert.end()
 })
 
@@ -399,9 +401,9 @@ test("add to front and remove", function (assert) {
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 4)
+    assert.equal(Dom(newRoot).childNodes.length, 4)
 
-    assert.equal(newRoot.childNodes[2], childNodes[0])
+    assert.equal(Dom(newRoot).childNodes[2], childNodes[0])
     assert.end()
 })
 
@@ -418,7 +420,7 @@ test("adding multiple widgets", function (assert) {
 
     FooWidget.prototype.update = function (prev, elem) {
         this.counter = prev.counter + 1
-        elem.textContent = this.foo + this.counter
+        Dom(elem).textContent = this.foo + this.counter
     }
 
     FooWidget.prototype.type = "Widget"
@@ -434,9 +436,9 @@ test("adding multiple widgets", function (assert) {
     rootNode = patch(rootNode, diff(firstTree, secondTree))
 
     assert.equal(rootNode.tagName, "DIV")
-    assert.equal(rootNode.childNodes.length, 1)
-    assert.equal(rootNode.childNodes[0].tagName, "DIV")
-    assert.equal(rootNode.childNodes[0].childNodes[0].data, "foo")
+    assert.equal(Dom(rootNode).childNodes.length, 1)
+    assert.equal(Dom(rootNode).childNodes[0].tagName, "DIV")
+    assert.equal(Dom(rootNode).childNodes[0].childNodes[0].data, "foo")
 
     var thirdTree = h("div", [
         new FooWidget("foo"),
@@ -445,7 +447,7 @@ test("adding multiple widgets", function (assert) {
     rootNode = patch(rootNode, diff(secondTree, thirdTree))
 
     assert.equal(rootNode.tagName, "DIV")
-    assert.equal(rootNode.childNodes.length, 2)
+    assert.equal(Dom(rootNode).childNodes.length, 2)
 
     assert.end()
 })
@@ -488,7 +490,7 @@ var itemHelpers = {
     },
 
     expectTextOfChild: function (assert, rootNode, childNo, text) {
-        assert.equal(rootNode.childNodes[childNo].id, text)
+        assert.equal(Dom(rootNode).childNodes[childNo].id, text)
     }
 }
 
@@ -771,7 +773,7 @@ function keyTest(itemsA, itemsB) {
         var rootNode = render(nodesA)
         patch(rootNode, patches)
 
-        var childNodes = rootNode.childNodes
+        var childNodes = Dom(rootNode).childNodes
 
         assertChildNodesFromArray(assert, itemsB, childNodes)
 
@@ -782,8 +784,8 @@ function keyTest(itemsA, itemsB) {
 
 function childNodesArray(node) {
     var childNodes = []
-    for (var i = 0; i < node.childNodes.length; i++) {
-        childNodes.push(node.childNodes[i])
+    for (var i = 0; i < Dom(node).childNodes.length; i++) {
+        childNodes.push(Dom(node).childNodes[i])
     }
     return childNodes
 }

--- a/test/main.js
+++ b/test/main.js
@@ -10,7 +10,7 @@ var version = require("../vnode/version")
 var assertEqualDom = require("./lib/assert-equal-dom.js")
 var patchCount = require("./lib/patch-count.js")
 
-
+var Dom = require("../polymer-dom.js")
 
 // VirtualNode tests
 test("Node is a function", function (assert) {
@@ -164,8 +164,8 @@ test("render text node", function (assert) {
     assert.equal(dom.tagName, "SPAN")
     assert.notOk(dom.id)
     assert.notOk(dom.className)
-    assert.equal(dom.childNodes.length, 1)
-    assert.equal(dom.childNodes[0].data, "hello")
+    assert.equal(Dom(dom).childNodes.length, 1)
+    assert.equal(Dom(dom).childNodes[0].data, "hello")
     assert.end()
 })
 
@@ -175,7 +175,7 @@ test("render div", function (assert) {
     assert.notOk(dom.id)
     assert.notOk(dom.className)
     assert.equal(dom.tagName, "DIV")
-    assert.equal(dom.childNodes.length, 0)
+    assert.equal(Dom(dom).childNodes.length, 0)
     assert.end()
 })
 
@@ -185,7 +185,7 @@ test("node id is applied correctly", function (assert) {
     assert.equal(dom.id, "important")
     assert.notOk(dom.className)
     assert.equal(dom.tagName, "DIV")
-    assert.equal(dom.childNodes.length, 0)
+    assert.equal(Dom(dom).childNodes.length, 0)
     assert.end()
 })
 
@@ -195,7 +195,7 @@ test("node class name is applied correctly", function (assert) {
     assert.notOk(dom.id)
     assert.equal(dom.className, "pretty")
     assert.equal(dom.tagName, "DIV")
-    assert.equal(dom.childNodes.length, 0)
+    assert.equal(Dom(dom).childNodes.length, 0)
     assert.end()
 })
 
@@ -205,7 +205,7 @@ test("mixture of node/classname applied correctly", function (assert) {
     assert.equal(dom.id, "important")
     assert.equal(dom.className, "very pretty")
     assert.equal(dom.tagName, "DIV")
-    assert.equal(dom.childNodes.length, 0)
+    assert.equal(Dom(dom).childNodes.length, 0)
     assert.end()
 })
 
@@ -220,7 +220,7 @@ test("style object is applied correctly", function (assert) {
     assert.equal(dom.tagName, "DIV")
     assert.equal(dom.style.border, style("border", "1px solid rgb(0, 0, 0)"))
     assert.equal(dom.style.padding, style("padding", "2px"))
-    assert.equal(dom.childNodes.length, 0)
+    assert.equal(Dom(dom).childNodes.length, 0)
     assert.end()
 })
 
@@ -237,9 +237,9 @@ test("children are added", function (assert) {
 
     var dom = render(vdom)
 
-    assert.equal(dom.childNodes.length, 3)
+    assert.equal(Dom(dom).childNodes.length, 3)
 
-    var nodes = dom.childNodes
+    var nodes = Dom(dom).childNodes
     assert.equal(nodes.length, 3)
     assert.equal(nodes[0].tagName, "DIV")
     assert.equal(nodes[1].data, "hello")
@@ -274,7 +274,7 @@ test("incompatible children are ignored", function (assert) {
     assert.equal(dom.className, "pretty")
     assert.equal(dom.tagName, "DIV")
     assert.equal(dom.style.cssText, style("cssText", "color: red;"))
-    assert.equal(dom.childNodes.length, 0)
+    assert.equal(Dom(dom).childNodes.length, 0)
     assert.end()
 })
 
@@ -333,7 +333,7 @@ test("injected warning is used", function (assert) {
     assert.equal(dom.className, "pretty")
     assert.equal(dom.tagName, "DIV")
     assert.equal(dom.style.cssText, style("cssText", "color: red;"))
-    assert.equal(dom.childNodes.length, 0)
+    assert.equal(Dom(dom).childNodes.length, 0)
     assert.equal(i, 2)
     assert.end()
 })
@@ -451,8 +451,8 @@ test("reuse dom node without breaking", function (assert) {
 test("Allow empty textnode", function (assert) {
     var empty = h("span", "")
     var rootNode = render(empty)
-    assert.equal(rootNode.childNodes.length, 1)
-    assert.equal(rootNode.childNodes[0].data, "")
+    assert.equal(Dom(rootNode).childNodes.length, 1)
+    assert.equal(Dom(rootNode).childNodes[0].data, "")
     assert.end()
 })
 
@@ -463,8 +463,8 @@ test("Can replace vnode with vtext", function (assert) {
 
     var rootNode = render(leftNode)
 
-    assert.equal(rootNode.childNodes.length, 1)
-    assert.equal(rootNode.childNodes[0].nodeType, 1)
+    assert.equal(Dom(rootNode).childNodes.length, 1)
+    assert.equal(Dom(rootNode).childNodes[0].nodeType, 1)
 
     var patches = diff(leftNode, rightNode)
 
@@ -472,8 +472,8 @@ test("Can replace vnode with vtext", function (assert) {
 
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 1)
-    assert.equal(newRoot.childNodes[0].nodeType, 3)
+    assert.equal(Dom(newRoot).childNodes.length, 1)
+    assert.equal(Dom(newRoot).childNodes[0].nodeType, 3)
 
     assert.end()
 })
@@ -525,7 +525,7 @@ test("Nested widget is initialised on render", function (assert) {
     var result = render(vdom)
 
     assert.equal(initCount, 1)
-    assert.equal(result.childNodes[1].childNodes[0], testNode)
+    assert.equal(Dom(result).childNodes[1].childNodes[0], testNode)
     assert.end()
 })
 
@@ -603,7 +603,7 @@ test("Patch nested widgets", function (assert) {
         updateCount++
         assert.equal(this.state, rightState)
         assert.equal(leftNode.state, leftState)
-        assert.equal(dom, domNode.childNodes[1].childNodes[0])
+        assert.equal(dom, Dom(domNode).childNodes[1].childNodes[0])
         patch(dom, diff(leftNode.vdom, this.vdom))
     }
 
@@ -667,8 +667,8 @@ test("Can replace stateful widget with vnode", function (assert) {
 
     var rootNode = render(leftNode)
 
-    assert.equal(rootNode.childNodes.length, 1)
-    assert.equal(rootNode.childNodes[0].className, 'widget')
+    assert.equal(Dom(rootNode).childNodes.length, 1)
+    assert.equal(Dom(rootNode).childNodes[0].className, 'widget')
 
     var patches = diff(leftNode, rightNode)
 
@@ -676,8 +676,8 @@ test("Can replace stateful widget with vnode", function (assert) {
 
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 1)
-    assert.equal(newRoot.childNodes[0].className, 'vnode')
+    assert.equal(Dom(newRoot).childNodes.length, 1)
+    assert.equal(Dom(newRoot).childNodes[0].className, 'vnode')
 
     assert.end()
 })
@@ -697,8 +697,8 @@ test("Can replace vnode with stateful widget with vnode", function (assert) {
 
     var rootNode = render(leftNode)
 
-    assert.equal(rootNode.childNodes.length, 1)
-    assert.equal(rootNode.childNodes[0].className, 'vnode')
+    assert.equal(Dom(rootNode).childNodes.length, 1)
+    assert.equal(Dom(rootNode).childNodes[0].className, 'vnode')
 
     var patches = diff(leftNode, rightNode)
 
@@ -706,8 +706,8 @@ test("Can replace vnode with stateful widget with vnode", function (assert) {
 
     assert.equal(newRoot, rootNode)
 
-    assert.equal(newRoot.childNodes.length, 1)
-    assert.equal(newRoot.childNodes[0].className, 'widget')
+    assert.equal(Dom(newRoot).childNodes.length, 1)
+    assert.equal(Dom(newRoot).childNodes[0].className, 'widget')
 
     assert.end()
 })
@@ -939,11 +939,11 @@ test("Widget update can replace domNode", function (assert) {
     var rootNode
 
     rootNode = render(initTree)
-    assert.equal(rootNode.childNodes[0], widgetInit)
+    assert.equal(Dom(rootNode).childNodes[0], widgetInit)
 
     patch(rootNode, diff(initTree, updateTree))
 
-    assert.equal(rootNode.childNodes[0], widgetUpdate)
+    assert.equal(Dom(rootNode).childNodes[0], widgetUpdate)
     assert.end()
 })
 

--- a/test/sort.js
+++ b/test/sort.js
@@ -35,9 +35,11 @@ var assert = require('assert');
 
 var document = require('global/document');
 
+var Dom = require("../polymer-dom.js")
+
 var testlingOutput = document.getElementById('__testling_output');
 if (testlingOutput) {
-    testlingOutput.parentNode.removeChild(testlingOutput);
+    Dom(testlingOutput.parentNode).removeChild(testlingOutput);
 }
 
 runTest();
@@ -78,12 +80,12 @@ function runBench(permutations) {
         var shuffled = nodesFromArray(item.shuffled);
 
         var rootNode = render(shuffled);
-        document.body.appendChild(rootNode);
+        Dom(document.body).appendChild(rootNode);
         var reflow = rootNode.offsetWidth;
         var patches = diff(shuffled, goal);
         patch(rootNode, patches);
         reflow = rootNode.offsetWidth;
-        document.body.removeChild(rootNode);
+        Dom(document.body).removeChild(rootNode);
     }
 
     var totalTime = Date.now() - startTime;
@@ -107,7 +109,7 @@ function runSort(permutations) {
         var patches = diff(shuffled, goal);
         patch(rootNode, patches);
 
-        assertChildNodesFromArray(assert, item.goal, rootNode.childNodes);
+        assertChildNodesFromArray(assert, item.goal, Dom(rootNode).childNodes);
     }
 
     console.log('All permutations sorted correctly');

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -1,6 +1,8 @@
 var isObject = require("is-object")
 var isHook = require("../vnode/is-vhook.js")
 
+var Dom = require("../polymer-dom.js")
+
 module.exports = applyProperties
 
 function applyProperties(node, props, previous) {
@@ -33,7 +35,7 @@ function removeProperty(node, propName, propValue, previous) {
         if (!isHook(previousValue)) {
             if (propName === "attributes") {
                 for (var attrName in previousValue) {
-                    node.removeAttribute(attrName)
+                    Dom(node).removeAttribute(attrName)
                 }
             } else if (propName === "style") {
                 for (var i in previousValue) {
@@ -59,9 +61,9 @@ function patchObject(node, props, previous, propName, propValue) {
             var attrValue = propValue[attrName]
 
             if (attrValue === undefined) {
-                node.removeAttribute(attrName)
+                Dom(node).removeAttribute(attrName)
             } else {
-                node.setAttribute(attrName, attrValue)
+                Dom(node).setAttribute(attrName, attrValue)
             }
         }
 

--- a/vdom/create-element.js
+++ b/vdom/create-element.js
@@ -7,6 +7,8 @@ var isVText = require("../vnode/is-vtext.js")
 var isWidget = require("../vnode/is-widget.js")
 var handleThunk = require("../vnode/handle-thunk.js")
 
+var Dom = require("../polymer-dom.js")
+
 module.exports = createElement
 
 function createElement(vnode, opts) {
@@ -38,7 +40,7 @@ function createElement(vnode, opts) {
     for (var i = 0; i < children.length; i++) {
         var childNode = createElement(children[i], opts)
         if (childNode) {
-            node.appendChild(childNode)
+            Dom(node).appendChild(childNode)
         }
     }
 

--- a/vdom/dom-index.js
+++ b/vdom/dom-index.js
@@ -4,6 +4,8 @@
 // We only recurse into a DOM node if we know that it contains a child of
 // interest.
 
+var Dom = require("../polymer-dom.js")
+
 var noChild = {}
 
 module.exports = domIndex
@@ -30,7 +32,7 @@ function recurse(rootNode, tree, indices, nodes, rootIndex) {
 
         if (vChildren) {
 
-            var childNodes = rootNode.childNodes
+            var childNodes = Dom(rootNode).childNodes
 
             for (var i = 0; i < tree.children.length; i++) {
                 rootIndex += 1

--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -5,6 +5,8 @@ var VPatch = require("../vnode/vpatch.js")
 
 var updateWidget = require("./update-widget")
 
+var Dom = require("../polymer-dom.js")
+
 module.exports = applyPatch
 
 function applyPatch(vpatch, domNode, renderOptions) {
@@ -38,10 +40,10 @@ function applyPatch(vpatch, domNode, renderOptions) {
 }
 
 function removeNode(domNode, vNode) {
-    var parentNode = domNode.parentNode
+    var parentNode = Dom(domNode).parentNode
 
     if (parentNode) {
-        parentNode.removeChild(domNode)
+        Dom(parentNode).removeChild(domNode)
     }
 
     destroyWidget(domNode, vNode);
@@ -53,7 +55,7 @@ function insertNode(parentNode, vNode, renderOptions) {
     var newNode = renderOptions.render(vNode, renderOptions)
 
     if (parentNode) {
-        parentNode.appendChild(newNode)
+        Dom(parentNode).appendChild(newNode)
     }
 
     return parentNode
@@ -66,7 +68,7 @@ function stringPatch(domNode, leftVNode, vText, renderOptions) {
         domNode.replaceData(0, domNode.length, vText.text)
         newNode = domNode
     } else {
-        var parentNode = domNode.parentNode
+        var parentNode = Dom(domNode).parentNode
         newNode = renderOptions.render(vText, renderOptions)
 
         if (parentNode && newNode !== domNode) {
@@ -87,7 +89,7 @@ function widgetPatch(domNode, leftVNode, widget, renderOptions) {
         newNode = renderOptions.render(widget, renderOptions)
     }
 
-    var parentNode = domNode.parentNode
+    var parentNode = Dom(domNode).parentNode
 
     if (parentNode && newNode !== domNode) {
         parentNode.replaceChild(newNode, domNode)
@@ -101,7 +103,7 @@ function widgetPatch(domNode, leftVNode, widget, renderOptions) {
 }
 
 function vNodePatch(domNode, leftVNode, vNode, renderOptions) {
-    var parentNode = domNode.parentNode
+    var parentNode = Dom(domNode).parentNode
     var newNode = renderOptions.render(vNode, renderOptions)
 
     if (parentNode && newNode !== domNode) {
@@ -118,7 +120,7 @@ function destroyWidget(domNode, w) {
 }
 
 function reorderChildren(domNode, moves) {
-    var childNodes = domNode.childNodes
+    var childNodes = Dom(domNode).childNodes
     var keyMap = {}
     var node
     var remove
@@ -130,7 +132,7 @@ function reorderChildren(domNode, moves) {
         if (remove.key) {
             keyMap[remove.key] = node
         }
-        domNode.removeChild(node)
+        Dom(domNode).removeChild(node)
     }
 
     var length = childNodes.length
@@ -138,13 +140,13 @@ function reorderChildren(domNode, moves) {
         insert = moves.inserts[j]
         node = keyMap[insert.key]
         // this is the weirdest bug i've ever seen in webkit
-        domNode.insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
+        Dom(domNode).insertBefore(node, insert.to >= length++ ? null : childNodes[insert.to])
     }
 }
 
 function replaceRoot(oldRoot, newRoot) {
-    if (oldRoot && newRoot && oldRoot !== newRoot && oldRoot.parentNode) {
-        oldRoot.parentNode.replaceChild(newRoot, oldRoot)
+    if (oldRoot && newRoot && oldRoot !== newRoot && Dom(oldRoot).parentNode) {
+        Dom(oldRoot).parentNode.replaceChild(newRoot, oldRoot)
     }
 
     return newRoot;

--- a/vdom/test/dom-index.js
+++ b/vdom/test/dom-index.js
@@ -6,6 +6,8 @@ var diff = require("../../vtree/diff")
 var createElement = require("../create-element")
 var patch = require("../patch")
 
+var Dom = require("../../polymer-dom.js")
+
 test("indexing over thunk root", function (assert) {
     var leftThunk = {
         type: "Thunk",
@@ -29,7 +31,7 @@ test("indexing over thunk root", function (assert) {
     var patches = diff(leftThunk, rightThunk)
     var newRoot = patch(root, patches)
 
-    assert.equal(newRoot.childNodes[0].data, "Right")
+    assert.equal(Dom(newRoot).childNodes[0].data, "Right")
     assert.end()
 })
 
@@ -71,6 +73,6 @@ test("indexing over thunk child", function (assert) {
     var root = createElement(leftNode)
     var patches = diff(leftNode, rightNode)
     patch(root, patches)
-    assert.equal(root.childNodes[2].childNodes[0].data, "Right")
+    assert.equal(Dom(root).childNodes[2].childNodes[0].data, "Right")
     assert.end()
 })

--- a/vdom/test/patch-op-index.js
+++ b/vdom/test/patch-op-index.js
@@ -7,6 +7,8 @@ var document = require("global/document")
 var createElement = require("../create-element")
 var patch = require("../patch")
 
+var Dom = require("../../polymer-dom.js")
+
 var createElementCustom = function(vnode) {
     var created = createElement(vnode)
     created.customCreation = true
@@ -17,7 +19,7 @@ function assertPachedNodeIsMarked(leftNode, rightNode, assert) {
     var root = createElementCustom(leftNode)
     var patches = diff(leftNode, rightNode)
     var newRoot = patch(root, patches, { render: createElementCustom })
-    assert.equal(newRoot.childNodes[0].customCreation, true)
+    assert.equal(Dom(newRoot).childNodes[0].customCreation, true)
     assert.end()
 }
 


### PR DESCRIPTION
Hi,

I've setup this pull request to get feedback on whether it is possible to get polymer support, and whether this is the right way to do it.

Currently virtual-dom doesn't work with webcomponents or polymer when shadow dom polyfills are used. This is because when using polyfills, the Shadow dom nodes affect the native dom manipulation methods. Polymer offers a simple API to wrap all these native calls so that dom manipulation works both with and without shadow dom.

In this approach - I simply replaced all the direct dom manipulation with polymer api (if it is present), which seems to work with shadow dom.

**_Note that this doesn't actually import Polymer into the codebase (that would be unthinkable). It simply checks for the presence of polymer, and if present makes itself compatible.**_

The tests will definitely fail for this, so I've marked this as do not merge.

Let me know what you think.
