### PR TITLE
Allow virtual-hyperscript to use spread notation

### DIFF
--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -16,13 +16,29 @@ var evHook = require('./hooks/ev-hook.js');
 
 module.exports = h;
 
-function h(tagName, properties, children) {
+function h(tagName, properties) {
+
+    var len = arguments.length;
+    var children;
     var childNodes = [];
     var tag, props, key, namespace;
 
-    if (!children && isChildren(properties)) {
-        children = properties;
-        props = {};
+    // Simulate spread operator
+    if (len >= 2) {
+        var from = 2;
+
+        if (isChildren(properties)) {
+            from = 1;
+            props = {};
+        }
+
+        if (len > from) {
+            children = Array(len - from);
+
+            for (var k = from; k < len; k++) {
+                children[k - from] = arguments[k];
+            }
+        }
     }
 
     props = props || properties || {};

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -91,6 +91,34 @@ test("h with children", function (assert) {
     assert.end()
 })
 
+test("h with spread children", function (assert) {
+    var node = h("div", h("span"), h("h1"));
+
+    assert.equal(node.children[0].tagName, "SPAN");
+    assert.equal(node.children[1].tagName, "H1");
+
+    assert.end()
+})
+
+test("h with properties and spread children", function (assert) {
+    var node = h("div", { key: "bar" }, h("span"), h("h1"));
+
+    assert.equal(node.key, "bar")
+    assert.equal(node.children[0].tagName, "SPAN");
+    assert.equal(node.children[1].tagName, "H1");
+
+    assert.end()
+})
+
+test("h with undefined properties and children", function(assert) {
+    var node = h("div", undefined, h("span"));
+
+    assert.comment(node.children[0].tagName)
+    assert.equal(node.children[0].tagName, "SPAN")
+
+    assert.end()
+})
+
 test("h with null", function (assert) {
     var node = h("div", null)
     var node2 = h("div", [null])


### PR DESCRIPTION
Babel JSX builtin JSX transformation use a spread form for the children of a node:
```js
h("div", options, h("span"), h("span"))
```
while virtual-hyperscript only allow the use of a single array of child.

This PR adapt the `h` function to take either an array or a list of arguments and thus providing a native compatibility with existing JSX transformer.