### PR TITLE
Fix failing spec so that test suite passes again

### DIFF
--- a/test/non-string.js
+++ b/test/non-string.js
@@ -9,6 +9,6 @@ test("coerce numbers to strings in children array", function (assert) {
     var rightNode = h("div", [ "clicked ", 1337, " times" ])
     var rootNode = createElement(leftNode)
     var newRoot = patch(rootNode, diff(leftNode, rightNode))
-    assert.equal(newRoot.toString(), '<div>clicked 1337 times</div>')
+    assert.equal(newRoot.outerHTML || newRoot.toString(), '<div>clicked 1337 times</div>')
     assert.end()
 })


### PR DESCRIPTION
Checking for the HTML of an element seems to be environmentally dependent. `.toString()` failing on testling, while `.outerHTML` failing during coverage checks.
