### PR TITLE
Add reference to dom2hscript in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ virtual-dom is heavily inspired by the inner workings of React by facebook. This
 ## Tools
 
 * [html2hscript](https://github.com/twilson63/html2hscript) - Parse HTML into hyperscript
+* [dom2hscript](https://github.com/AkeemMcLennon/dom2hscript) - Frontend library for parsing HTML into hyperscript using the browser's built in parser.
 * [html2hscript.herokuapp.com](http://html2hscript.herokuapp.com/) - Online Tool that converts html snippets to hyperscript
 * [html2hyperscript](https://github.com/unframework/html2hyperscript) - Original commandline utility to convert legacy HTML markup into hyperscript
 


### PR DESCRIPTION
Hello everyone,

I ended up creating a client side version of twilson63/html2hscript that uses the browser's built in DOM and CSS parser at https://github.com/AkeemMcLennon/dom2hscript

Although I'm still using html2hscript in the backend, the 200kb dependency on htmlparser2 was too large for use in production. However, this dependency is no longer necessary in the browser context.