### PR TITLE
try catch attributes

### DIFF
--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -61,7 +61,14 @@ function patchObject(node, props, previous, propName, propValue) {
             if (attrValue === undefined) {
                 node.removeAttribute(attrName)
             } else {
-                node.setAttribute(attrName, attrValue)
+                try {
+                  node.setAttribute(attrName, attrValue)
+                }
+
+                catch(e) {
+                  node.removeAttribute(attrName)
+                }
+
             }
         }
 


### PR DESCRIPTION
For the error: `failed to setAttribute for X`.

There are scenarios (usually typo) where a bad property is added. `node.setAttribute` does not fail in a useful manner (script just stops).

I've setup a `try/catch` so that if a bad property is attempted to be added, on failure it is removed from the list.

I understand that the developer of said application should make sure that the bad property is not present, but at the very least I'd like this pull request to be a record of what is stopping execution.