### PR TITLE
Support custom element types via type extensions

### DIFF
--- a/vdom/create-element.js
+++ b/vdom/create-element.js
@@ -26,11 +26,13 @@ function createElement(vnode, opts) {
         return null
     }
 
-    var node = (vnode.namespace === null) ?
-        doc.createElement(vnode.tagName) :
-        doc.createElementNS(vnode.namespace, vnode.tagName)
-
     var props = vnode.properties
+    var type = props && props.attributes && props.attributes.is || null
+
+    var node = (vnode.namespace === null) ?
+        doc.createElement(vnode.tagName, type) :
+        doc.createElementNS(vnode.namespace, vnode.tagName, type)
+
     applyProperties(node, props)
 
     var children = vnode.children


### PR DESCRIPTION
- Moved `props` up to make it accessible before element instantiation
- Added a type variable, which is either the value of
  `properties.attributes.is` or `null`
- Amended `doc.createElement` to supply the second parameter for type
  extensions