### PR TITLE
Accept multiple arguments for children in h()

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "browser-split": "0.0.1",
     "error": "^4.3.0",
     "ev-store": "^7.0.0",
+    "flatten": "0.0.1",
     "global": "^4.3.0",
     "is-object": "^1.0.1",
     "next-tick": "^0.2.2",

--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var isArray = require('x-is-array');
+var flatten = require('flatten');
 
 var VNode = require('../vnode/vnode.js');
 var VText = require('../vnode/vtext.js');
@@ -23,6 +24,8 @@ function h(tagName, properties, children) {
     if (!children && isChildren(properties)) {
         children = properties;
         props = {};
+    } else if (arguments.length > 3) {
+        children = flatten([].slice.call(arguments, 2));
     }
 
     props = props || properties || {};


### PR DESCRIPTION
This small variation allows h() to be used directly in place of React.createElement in babel-transform-react-jsx.  That babel transform seems to turn something like:

```jsx
<div>I am a {banana}</div>
```

Into 

```js
createElement('div', null, 'I am a', banana)
```

Instead of

```js
createElement('div', null, ['I am a', banana])
```

Which is what `h()` currently needs.