### PR TITLE
Remove unused parameter from domIndex

### DIFF
--- a/vdom/dom-index.js
+++ b/vdom/dom-index.js
@@ -8,12 +8,12 @@ var noChild = {}
 
 module.exports = domIndex
 
-function domIndex(rootNode, tree, indices, nodes) {
+function domIndex(rootNode, tree, indices) {
     if (!indices || indices.length === 0) {
         return {}
     } else {
         indices.sort(ascending)
-        return recurse(rootNode, tree, indices, nodes, 0)
+        return recurse(rootNode, tree, indices, undefined, 0)
     }
 }
 


### PR DESCRIPTION
`domIndex` is only used in one place in the source code, in vdom/patch.js, and it is called with three parameters.
