### PR TITLE
Guard against `Failed to execute 'removeChild' on 'Node'` error

### DIFF
--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -41,7 +41,12 @@ function removeNode(domNode, vNode) {
     var parentNode = domNode.parentNode
 
     if (parentNode) {
-        parentNode.removeChild(domNode)
+        // removeChild() errors in Chrome in some edge cases
+        // see: http://stackoverflow.com/questions/21926083/failed-to-execute-removechild-on-node
+        try {
+            parentNode.removeChild(domNode)
+        }
+        catch() {}
     }
 
     destroyWidget(domNode, vNode);


### PR DESCRIPTION
Chrome throws `Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?` in some edge-cases.