### PR TITLE
Throw errors when passing invalid input values

### DIFF
--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -47,6 +47,16 @@ function h(tagName, properties, children) {
         props.value !== undefined &&
         !isHook(props.value)
     ) {
+        if (props.value !== null && typeof props.value !== 'string') {
+            throw UnsupportedValueType({
+                expected: 'String',
+                received: typeof props.value,
+                Vnode: {
+                    tagName: tag,
+                    properties: props
+                }
+            });
+        }
         props.value = softSetHook(props.value);
     }
 
@@ -124,6 +134,25 @@ function UnexpectedVirtualElement(data) {
         'Suggested fix: change your `h(..., [ ... ])` callsite.';
     err.foreignObject = data.foreignObject;
     err.parentVnode = data.parentVnode;
+
+    return err;
+}
+
+function UnsupportedValueType(data) {
+    var err = new Error();
+
+    err.type = 'virtual-hyperscript.unsupported.value-type';
+    err.message = 'Unexpected value type for input passed to h().\n' +
+        'Expected a ' +
+        errorString(data.expected) +
+        ' but got:\n' +
+        errorString(data.received) +
+        '.\n' +
+        'The vnode is:\n' +
+        errorString(data.Vnode)
+        '\n' +
+        'Suggested fix: Cast the value passed to h() to a string using String(value).';
+    err.Vnode = data.Vnode;
 
     return err;
 }

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -75,6 +75,23 @@ test("input.value soft hook", function (assert) {
     assert.end()
 })
 
+test("input.value must be string", function (assert) {
+    assert.throws(function() {
+        var node = h("input", { value: 1234 })
+    });
+
+    assert.throws(function() {
+        var node = h("input", { value: {} })
+    });
+
+    assert.throws(function() {
+        var undefined;
+        var node = h("input", { value: undefined })
+    });
+
+    assert.end()
+})
+
 test("h with child", function (assert) {
     var node = h("div", h("span"))
 

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -84,11 +84,6 @@ test("input.value must be string", function (assert) {
         var node = h("input", { value: {} })
     });
 
-    assert.throws(function() {
-        var undefined;
-        var node = h("input", { value: undefined })
-    });
-
     assert.end()
 })
 


### PR DESCRIPTION
Currently, if you pass any non-string into the `value` property of an input, when it does the hook patch the value will not `===` the current value of the input since inputs always return strings regardless of what value they were set to.

The end result is that if you pass something like a number in, cursor position is not maintained and it will constantly reset you to the end of line, editing the value of the input since `123 !== "123"`