### PR TITLE
make variable name more reasonable

### DIFF
--- a/virtual-hyperscript/parse-tag.js
+++ b/virtual-hyperscript/parse-tag.js
@@ -3,7 +3,7 @@
 var split = require('browser-split');
 
 var classIdSplit = /([\.#]?[a-zA-Z0-9\u007F-\uFFFF_:-]+)/;
-var notClassId = /^\.|#/;
+var isClassId = /^\.|#/;
 
 module.exports = parseTag;
 
@@ -17,7 +17,7 @@ function parseTag(tag, props) {
     var tagParts = split(tag, classIdSplit);
     var tagName = null;
 
-    if (notClassId.test(tagParts[1])) {
+    if (isClassId.test(tagParts[1])) {
         tagName = 'DIV';
     }
 


### PR DESCRIPTION
The variable `notClassId` is used in <https://github.com/Matt-Esch/virtual-dom/blob/master/virtual-hyperscript/parse-tag.js#L6-L20>:

```js
var notClassId = /^\.|#/;
// ...
    if (notClassId.test(tagParts[1])) {
        tagName = 'DIV';
    }
```

The regexp `notClassId` aims to test whether a string is `id` or `class`. 

If `tagParts[1]` is `id` or `class`, it means tagName is not specified, set it default to `'DIV'`.

So, I think rename it (`notClassId`) to `isClassId` is more reasonable.