### PR TITLE
vDOM and 'style' h tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ compile
 .lock-wscript
 coverage
 node_modules
+examples/

--- a/dist/virtual-dom.js
+++ b/dist/virtual-dom.js
@@ -863,7 +863,7 @@ function h(tagName, properties, children) {
     // parse styles
     if (tag == 'STYLE' && properties){
         childNodes = parseStyles(properties);
-        properties = null
+        props = null
     }
 
     // fix cursor bug
@@ -974,9 +974,11 @@ function parseStyles(properties){
 	var content = JSON.stringify(props)
 	content = content
 		.substring(1,content.length -1)
+		.replace(/\"\,\"/g,'";"')
 		.replace(/\'|\"/g,'')
 		.replace(/\:\{/g,'{')
 		.replace(/\}\,/g,'}')
+		.replace(/([a-z\d])([A-Z])/g,'$1-$2').toLowerCase()
 
 	return [new VText(content)];
 }

--- a/dist/virtual-dom.js
+++ b/dist/virtual-dom.js
@@ -10,7 +10,7 @@ var diff = require("./vtree/diff.js")
 
 module.exports = diff
 
-},{"./vtree/diff.js":36}],4:[function(require,module,exports){
+},{"./vtree/diff.js":37}],4:[function(require,module,exports){
 var h = require("./virtual-hyperscript/index.js")
 
 module.exports = h
@@ -34,7 +34,7 @@ module.exports = {
     vDOM: vDOM
 }
 
-},{"./create-element.js":2,"./diff.js":3,"./h.js":4,"./patch.js":13,"./vDOM.js":14,"./vnode/vnode.js":32,"./vnode/vtext.js":34}],6:[function(require,module,exports){
+},{"./create-element.js":2,"./diff.js":3,"./h.js":4,"./patch.js":13,"./vDOM.js":14,"./vnode/vnode.js":33,"./vnode/vtext.js":35}],6:[function(require,module,exports){
 /*!
  * Cross-Browser Split 1.1.1
  * Copyright 2007-2012 Steven Levithan <stevenlevithan.com>
@@ -380,7 +380,7 @@ function getPrototype(value) {
     }
 }
 
-},{"../vnode/is-vhook.js":27,"is-object":11}],16:[function(require,module,exports){
+},{"../vnode/is-vhook.js":28,"is-object":11}],16:[function(require,module,exports){
 var document = require("global/document")
 
 var applyProperties = require("./apply-properties")
@@ -428,7 +428,7 @@ function createElement(vnode, opts) {
     return node
 }
 
-},{"../vnode/handle-thunk.js":25,"../vnode/is-vnode.js":28,"../vnode/is-vtext.js":29,"../vnode/is-widget.js":30,"./apply-properties":15,"global/document":8}],17:[function(require,module,exports){
+},{"../vnode/handle-thunk.js":26,"../vnode/is-vnode.js":29,"../vnode/is-vtext.js":30,"../vnode/is-widget.js":31,"./apply-properties":15,"global/document":8}],17:[function(require,module,exports){
 // Maps a virtual DOM tree onto a real DOM tree in an efficient manner.
 // We don't want to read all of the DOM nodes in the tree so we use
 // the in-order tree indexing to eliminate recursion down certain branches.
@@ -668,7 +668,7 @@ function replaceRoot(oldRoot, newRoot) {
     return newRoot;
 }
 
-},{"../vnode/is-widget.js":30,"../vnode/vpatch.js":33,"./apply-properties":15,"./update-widget":20}],19:[function(require,module,exports){
+},{"../vnode/is-widget.js":31,"../vnode/vpatch.js":34,"./apply-properties":15,"./update-widget":20}],19:[function(require,module,exports){
 var document = require("global/document")
 var isArray = require("x-is-array")
 
@@ -767,7 +767,7 @@ function updateWidget(a, b) {
     return false
 }
 
-},{"../vnode/is-widget.js":30}],21:[function(require,module,exports){
+},{"../vnode/is-widget.js":31}],21:[function(require,module,exports){
 'use strict';
 
 var EvStore = require('ev-store');
@@ -832,6 +832,8 @@ var parseTag = require('./parse-tag.js');
 var softSetHook = require('./hooks/soft-set-hook.js');
 var evHook = require('./hooks/ev-hook.js');
 
+var parseStyles = require('./parse-styles');
+
 module.exports = h;
 
 function h(tagName, properties, children) {
@@ -856,6 +858,12 @@ function h(tagName, properties, children) {
     if (props.hasOwnProperty('namespace')) {
         namespace = props.namespace;
         props.namespace = undefined;
+    }
+
+    // parse styles
+    if (tag == 'STYLE' && properties){
+        childNodes = parseStyles(properties);
+        properties = null
     }
 
     // fix cursor bug
@@ -954,7 +962,25 @@ function errorString(obj) {
     }
 }
 
-},{"../vnode/is-thunk":26,"../vnode/is-vhook":27,"../vnode/is-vnode":28,"../vnode/is-vtext":29,"../vnode/is-widget":30,"../vnode/vnode.js":32,"../vnode/vtext.js":34,"./hooks/ev-hook.js":21,"./hooks/soft-set-hook.js":22,"./parse-tag.js":24,"x-is-array":12}],24:[function(require,module,exports){
+},{"../vnode/is-thunk":27,"../vnode/is-vhook":28,"../vnode/is-vnode":29,"../vnode/is-vtext":30,"../vnode/is-widget":31,"../vnode/vnode.js":33,"../vnode/vtext.js":35,"./hooks/ev-hook.js":21,"./hooks/soft-set-hook.js":22,"./parse-styles":24,"./parse-tag.js":25,"x-is-array":12}],24:[function(require,module,exports){
+var VText = require('../vnode/vtext.js');
+
+module.exports = parseStyles;
+
+function parseStyles(properties){
+	
+	var props = properties || []
+
+	var content = JSON.stringify(props)
+	content = content
+		.substring(1,content.length -1)
+		.replace(/\'|\"/g,'')
+		.replace(/\:\{/g,'{')
+		.replace(/\}\,/g,'}')
+
+	return [new VText(content)];
+}
+},{"../vnode/vtext.js":35}],25:[function(require,module,exports){
 'use strict';
 
 var split = require('browser-split');
@@ -1010,7 +1036,7 @@ function parseTag(tag, props) {
     return props.namespace ? tagName : tagName.toUpperCase();
 }
 
-},{"browser-split":6}],25:[function(require,module,exports){
+},{"browser-split":6}],26:[function(require,module,exports){
 var isVNode = require("./is-vnode")
 var isVText = require("./is-vtext")
 var isWidget = require("./is-widget")
@@ -1052,14 +1078,14 @@ function renderThunk(thunk, previous) {
     return renderedThunk
 }
 
-},{"./is-thunk":26,"./is-vnode":28,"./is-vtext":29,"./is-widget":30}],26:[function(require,module,exports){
+},{"./is-thunk":27,"./is-vnode":29,"./is-vtext":30,"./is-widget":31}],27:[function(require,module,exports){
 module.exports = isThunk
 
 function isThunk(t) {
     return t && t.type === "Thunk"
 }
 
-},{}],27:[function(require,module,exports){
+},{}],28:[function(require,module,exports){
 module.exports = isHook
 
 function isHook(hook) {
@@ -1068,7 +1094,7 @@ function isHook(hook) {
        typeof hook.unhook === "function" && !hook.hasOwnProperty("unhook"))
 }
 
-},{}],28:[function(require,module,exports){
+},{}],29:[function(require,module,exports){
 var version = require("./version")
 
 module.exports = isVirtualNode
@@ -1077,7 +1103,7 @@ function isVirtualNode(x) {
     return x && x.type === "VirtualNode" && x.version === version
 }
 
-},{"./version":31}],29:[function(require,module,exports){
+},{"./version":32}],30:[function(require,module,exports){
 var version = require("./version")
 
 module.exports = isVirtualText
@@ -1086,17 +1112,17 @@ function isVirtualText(x) {
     return x && x.type === "VirtualText" && x.version === version
 }
 
-},{"./version":31}],30:[function(require,module,exports){
+},{"./version":32}],31:[function(require,module,exports){
 module.exports = isWidget
 
 function isWidget(w) {
     return w && w.type === "Widget"
 }
 
-},{}],31:[function(require,module,exports){
+},{}],32:[function(require,module,exports){
 module.exports = "2"
 
-},{}],32:[function(require,module,exports){
+},{}],33:[function(require,module,exports){
 var version = require("./version")
 var isVNode = require("./is-vnode")
 var isWidget = require("./is-widget")
@@ -1170,7 +1196,7 @@ function VirtualNode(tagName, properties, children, key, namespace) {
 VirtualNode.prototype.version = version
 VirtualNode.prototype.type = "VirtualNode"
 
-},{"./is-thunk":26,"./is-vhook":27,"./is-vnode":28,"./is-widget":30,"./version":31}],33:[function(require,module,exports){
+},{"./is-thunk":27,"./is-vhook":28,"./is-vnode":29,"./is-widget":31,"./version":32}],34:[function(require,module,exports){
 var version = require("./version")
 
 VirtualPatch.NONE = 0
@@ -1194,7 +1220,7 @@ function VirtualPatch(type, vNode, patch) {
 VirtualPatch.prototype.version = version
 VirtualPatch.prototype.type = "VirtualPatch"
 
-},{"./version":31}],34:[function(require,module,exports){
+},{"./version":32}],35:[function(require,module,exports){
 var version = require("./version")
 
 module.exports = VirtualText
@@ -1206,7 +1232,7 @@ function VirtualText(text) {
 VirtualText.prototype.version = version
 VirtualText.prototype.type = "VirtualText"
 
-},{"./version":31}],35:[function(require,module,exports){
+},{"./version":32}],36:[function(require,module,exports){
 var isObject = require("is-object")
 var isHook = require("../vnode/is-vhook")
 
@@ -1266,7 +1292,7 @@ function getPrototype(value) {
   }
 }
 
-},{"../vnode/is-vhook":27,"is-object":11}],36:[function(require,module,exports){
+},{"../vnode/is-vhook":28,"is-object":11}],37:[function(require,module,exports){
 var isArray = require("x-is-array")
 
 var VPatch = require("../vnode/vpatch")
@@ -1695,5 +1721,5 @@ function appendPatch(apply, patch) {
     }
 }
 
-},{"../vnode/handle-thunk":25,"../vnode/is-thunk":26,"../vnode/is-vnode":28,"../vnode/is-vtext":29,"../vnode/is-widget":30,"../vnode/vpatch":33,"./diff-props":35,"x-is-array":12}]},{},[5])(5)
+},{"../vnode/handle-thunk":26,"../vnode/is-thunk":27,"../vnode/is-vnode":29,"../vnode/is-vtext":30,"../vnode/is-widget":31,"../vnode/vpatch":34,"./diff-props":36,"x-is-array":12}]},{},[5])(5)
 });

--- a/dist/virtual-dom.js
+++ b/dist/virtual-dom.js
@@ -1,25 +1,28 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.virtualDom=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.virtualDom = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+
+},{}],2:[function(require,module,exports){
 var createElement = require("./vdom/create-element.js")
 
 module.exports = createElement
 
-},{"./vdom/create-element.js":15}],2:[function(require,module,exports){
+},{"./vdom/create-element.js":16}],3:[function(require,module,exports){
 var diff = require("./vtree/diff.js")
 
 module.exports = diff
 
-},{"./vtree/diff.js":35}],3:[function(require,module,exports){
+},{"./vtree/diff.js":36}],4:[function(require,module,exports){
 var h = require("./virtual-hyperscript/index.js")
 
 module.exports = h
 
-},{"./virtual-hyperscript/index.js":22}],4:[function(require,module,exports){
+},{"./virtual-hyperscript/index.js":23}],5:[function(require,module,exports){
 var diff = require("./diff.js")
 var patch = require("./patch.js")
 var h = require("./h.js")
 var create = require("./create-element.js")
 var VNode = require('./vnode/vnode.js')
 var VText = require('./vnode/vtext.js')
+var vDOM = require('./vDOM.js')
 
 module.exports = {
     diff: diff,
@@ -27,10 +30,11 @@ module.exports = {
     h: h,
     create: create,
     VNode: VNode,
-    VText: VText
+    VText: VText,
+    vDOM: vDOM
 }
 
-},{"./create-element.js":1,"./diff.js":2,"./h.js":3,"./patch.js":13,"./vnode/vnode.js":31,"./vnode/vtext.js":33}],5:[function(require,module,exports){
+},{"./create-element.js":2,"./diff.js":3,"./h.js":4,"./patch.js":13,"./vDOM.js":14,"./vnode/vnode.js":32,"./vnode/vtext.js":34}],6:[function(require,module,exports){
 /*!
  * Cross-Browser Split 1.1.1
  * Copyright 2007-2012 Steven Levithan <stevenlevithan.com>
@@ -138,8 +142,6 @@ module.exports = (function split(undef) {
   return self;
 })();
 
-},{}],6:[function(require,module,exports){
-
 },{}],7:[function(require,module,exports){
 'use strict';
 
@@ -162,7 +164,26 @@ function EvStore(elem) {
     return hash;
 }
 
-},{"individual/one-version":9}],8:[function(require,module,exports){
+},{"individual/one-version":10}],8:[function(require,module,exports){
+(function (global){
+var topLevel = typeof global !== 'undefined' ? global :
+    typeof window !== 'undefined' ? window : {}
+var minDoc = require('min-document');
+
+if (typeof document !== 'undefined') {
+    module.exports = document;
+} else {
+    var doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'];
+
+    if (!doccy) {
+        doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'] = minDoc;
+    }
+
+    module.exports = doccy;
+}
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"min-document":1}],9:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -185,7 +206,7 @@ function Individual(key, value) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],9:[function(require,module,exports){
+},{}],10:[function(require,module,exports){
 'use strict';
 
 var Individual = require('./index.js');
@@ -209,26 +230,7 @@ function OneVersion(moduleName, version, defaultValue) {
     return Individual(key, defaultValue);
 }
 
-},{"./index.js":8}],10:[function(require,module,exports){
-(function (global){
-var topLevel = typeof global !== 'undefined' ? global :
-    typeof window !== 'undefined' ? window : {}
-var minDoc = require('min-document');
-
-if (typeof document !== 'undefined') {
-    module.exports = document;
-} else {
-    var doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'];
-
-    if (!doccy) {
-        doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'] = minDoc;
-    }
-
-    module.exports = doccy;
-}
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"min-document":6}],11:[function(require,module,exports){
+},{"./index.js":9}],11:[function(require,module,exports){
 "use strict";
 
 module.exports = function isObject(x) {
@@ -250,7 +252,36 @@ var patch = require("./vdom/patch.js")
 
 module.exports = patch
 
-},{"./vdom/patch.js":18}],14:[function(require,module,exports){
+},{"./vdom/patch.js":19}],14:[function(require,module,exports){
+var diff = require("./diff.js")
+var patch = require("./patch.js")
+var h = require("./h.js")
+var create = require("./create-element.js")
+
+function vDOM(){
+    
+  var tree = h('#root','');
+  var rootNode = create(tree);
+  document.body.appendChild(rootNode);
+
+  function update(newTree){
+    var patches = diff(tree, newTree);
+    rootNode = patch(rootNode, patches);
+    tree = newTree;
+  }
+  
+  return{
+      
+    render: function(tree){
+      update(tree);
+    }
+     
+  };
+    
+}
+
+module.exports = vDOM;
+},{"./create-element.js":2,"./diff.js":3,"./h.js":4,"./patch.js":13}],15:[function(require,module,exports){
 var isObject = require("is-object")
 var isHook = require("../vnode/is-vhook.js")
 
@@ -349,7 +380,7 @@ function getPrototype(value) {
     }
 }
 
-},{"../vnode/is-vhook.js":26,"is-object":11}],15:[function(require,module,exports){
+},{"../vnode/is-vhook.js":27,"is-object":11}],16:[function(require,module,exports){
 var document = require("global/document")
 
 var applyProperties = require("./apply-properties")
@@ -397,7 +428,7 @@ function createElement(vnode, opts) {
     return node
 }
 
-},{"../vnode/handle-thunk.js":24,"../vnode/is-vnode.js":27,"../vnode/is-vtext.js":28,"../vnode/is-widget.js":29,"./apply-properties":14,"global/document":10}],16:[function(require,module,exports){
+},{"../vnode/handle-thunk.js":25,"../vnode/is-vnode.js":28,"../vnode/is-vtext.js":29,"../vnode/is-widget.js":30,"./apply-properties":15,"global/document":8}],17:[function(require,module,exports){
 // Maps a virtual DOM tree onto a real DOM tree in an efficient manner.
 // We don't want to read all of the DOM nodes in the tree so we use
 // the in-order tree indexing to eliminate recursion down certain branches.
@@ -484,7 +515,7 @@ function ascending(a, b) {
     return a > b ? 1 : -1
 }
 
-},{}],17:[function(require,module,exports){
+},{}],18:[function(require,module,exports){
 var applyProperties = require("./apply-properties")
 
 var isWidget = require("../vnode/is-widget.js")
@@ -637,7 +668,7 @@ function replaceRoot(oldRoot, newRoot) {
     return newRoot;
 }
 
-},{"../vnode/is-widget.js":29,"../vnode/vpatch.js":32,"./apply-properties":14,"./update-widget":19}],18:[function(require,module,exports){
+},{"../vnode/is-widget.js":30,"../vnode/vpatch.js":33,"./apply-properties":15,"./update-widget":20}],19:[function(require,module,exports){
 var document = require("global/document")
 var isArray = require("x-is-array")
 
@@ -719,7 +750,7 @@ function patchIndices(patches) {
     return indices
 }
 
-},{"./create-element":15,"./dom-index":16,"./patch-op":17,"global/document":10,"x-is-array":12}],19:[function(require,module,exports){
+},{"./create-element":16,"./dom-index":17,"./patch-op":18,"global/document":8,"x-is-array":12}],20:[function(require,module,exports){
 var isWidget = require("../vnode/is-widget.js")
 
 module.exports = updateWidget
@@ -736,7 +767,7 @@ function updateWidget(a, b) {
     return false
 }
 
-},{"../vnode/is-widget.js":29}],20:[function(require,module,exports){
+},{"../vnode/is-widget.js":30}],21:[function(require,module,exports){
 'use strict';
 
 var EvStore = require('ev-store');
@@ -765,7 +796,7 @@ EvHook.prototype.unhook = function(node, propertyName) {
     es[propName] = undefined;
 };
 
-},{"ev-store":7}],21:[function(require,module,exports){
+},{"ev-store":7}],22:[function(require,module,exports){
 'use strict';
 
 module.exports = SoftSetHook;
@@ -784,7 +815,7 @@ SoftSetHook.prototype.hook = function (node, propertyName) {
     }
 };
 
-},{}],22:[function(require,module,exports){
+},{}],23:[function(require,module,exports){
 'use strict';
 
 var isArray = require('x-is-array');
@@ -923,7 +954,7 @@ function errorString(obj) {
     }
 }
 
-},{"../vnode/is-thunk":25,"../vnode/is-vhook":26,"../vnode/is-vnode":27,"../vnode/is-vtext":28,"../vnode/is-widget":29,"../vnode/vnode.js":31,"../vnode/vtext.js":33,"./hooks/ev-hook.js":20,"./hooks/soft-set-hook.js":21,"./parse-tag.js":23,"x-is-array":12}],23:[function(require,module,exports){
+},{"../vnode/is-thunk":26,"../vnode/is-vhook":27,"../vnode/is-vnode":28,"../vnode/is-vtext":29,"../vnode/is-widget":30,"../vnode/vnode.js":32,"../vnode/vtext.js":34,"./hooks/ev-hook.js":21,"./hooks/soft-set-hook.js":22,"./parse-tag.js":24,"x-is-array":12}],24:[function(require,module,exports){
 'use strict';
 
 var split = require('browser-split');
@@ -979,7 +1010,7 @@ function parseTag(tag, props) {
     return props.namespace ? tagName : tagName.toUpperCase();
 }
 
-},{"browser-split":5}],24:[function(require,module,exports){
+},{"browser-split":6}],25:[function(require,module,exports){
 var isVNode = require("./is-vnode")
 var isVText = require("./is-vtext")
 var isWidget = require("./is-widget")
@@ -1021,14 +1052,14 @@ function renderThunk(thunk, previous) {
     return renderedThunk
 }
 
-},{"./is-thunk":25,"./is-vnode":27,"./is-vtext":28,"./is-widget":29}],25:[function(require,module,exports){
+},{"./is-thunk":26,"./is-vnode":28,"./is-vtext":29,"./is-widget":30}],26:[function(require,module,exports){
 module.exports = isThunk
 
 function isThunk(t) {
     return t && t.type === "Thunk"
 }
 
-},{}],26:[function(require,module,exports){
+},{}],27:[function(require,module,exports){
 module.exports = isHook
 
 function isHook(hook) {
@@ -1037,7 +1068,7 @@ function isHook(hook) {
        typeof hook.unhook === "function" && !hook.hasOwnProperty("unhook"))
 }
 
-},{}],27:[function(require,module,exports){
+},{}],28:[function(require,module,exports){
 var version = require("./version")
 
 module.exports = isVirtualNode
@@ -1046,7 +1077,7 @@ function isVirtualNode(x) {
     return x && x.type === "VirtualNode" && x.version === version
 }
 
-},{"./version":30}],28:[function(require,module,exports){
+},{"./version":31}],29:[function(require,module,exports){
 var version = require("./version")
 
 module.exports = isVirtualText
@@ -1055,17 +1086,17 @@ function isVirtualText(x) {
     return x && x.type === "VirtualText" && x.version === version
 }
 
-},{"./version":30}],29:[function(require,module,exports){
+},{"./version":31}],30:[function(require,module,exports){
 module.exports = isWidget
 
 function isWidget(w) {
     return w && w.type === "Widget"
 }
 
-},{}],30:[function(require,module,exports){
+},{}],31:[function(require,module,exports){
 module.exports = "2"
 
-},{}],31:[function(require,module,exports){
+},{}],32:[function(require,module,exports){
 var version = require("./version")
 var isVNode = require("./is-vnode")
 var isWidget = require("./is-widget")
@@ -1139,7 +1170,7 @@ function VirtualNode(tagName, properties, children, key, namespace) {
 VirtualNode.prototype.version = version
 VirtualNode.prototype.type = "VirtualNode"
 
-},{"./is-thunk":25,"./is-vhook":26,"./is-vnode":27,"./is-widget":29,"./version":30}],32:[function(require,module,exports){
+},{"./is-thunk":26,"./is-vhook":27,"./is-vnode":28,"./is-widget":30,"./version":31}],33:[function(require,module,exports){
 var version = require("./version")
 
 VirtualPatch.NONE = 0
@@ -1163,7 +1194,7 @@ function VirtualPatch(type, vNode, patch) {
 VirtualPatch.prototype.version = version
 VirtualPatch.prototype.type = "VirtualPatch"
 
-},{"./version":30}],33:[function(require,module,exports){
+},{"./version":31}],34:[function(require,module,exports){
 var version = require("./version")
 
 module.exports = VirtualText
@@ -1175,7 +1206,7 @@ function VirtualText(text) {
 VirtualText.prototype.version = version
 VirtualText.prototype.type = "VirtualText"
 
-},{"./version":30}],34:[function(require,module,exports){
+},{"./version":31}],35:[function(require,module,exports){
 var isObject = require("is-object")
 var isHook = require("../vnode/is-vhook")
 
@@ -1235,7 +1266,7 @@ function getPrototype(value) {
   }
 }
 
-},{"../vnode/is-vhook":26,"is-object":11}],35:[function(require,module,exports){
+},{"../vnode/is-vhook":27,"is-object":11}],36:[function(require,module,exports){
 var isArray = require("x-is-array")
 
 var VPatch = require("../vnode/vpatch")
@@ -1664,5 +1695,5 @@ function appendPatch(apply, patch) {
     }
 }
 
-},{"../vnode/handle-thunk":24,"../vnode/is-thunk":25,"../vnode/is-vnode":27,"../vnode/is-vtext":28,"../vnode/is-widget":29,"../vnode/vpatch":32,"./diff-props":34,"x-is-array":12}]},{},[4])(4)
+},{"../vnode/handle-thunk":25,"../vnode/is-thunk":26,"../vnode/is-vnode":28,"../vnode/is-vtext":29,"../vnode/is-widget":30,"../vnode/vpatch":33,"./diff-props":35,"x-is-array":12}]},{},[5])(5)
 });

--- a/examples/styles.html
+++ b/examples/styles.html
@@ -1,0 +1,39 @@
+
+<!doctype html>
+<html lang="en">
+
+	<head>
+	  <meta charset="utf-8">
+	  <title>Styles</title>
+	</head>
+
+	<script src="../dist/virtual-dom.js"></script>
+
+	<body></body>
+
+	<script>
+		
+	var DOM = new virtualDom.vDOM()
+	var e = virtualDom.h
+
+	var el = e('#comp', 'I am stylish')
+	var b = e('.greeter', 'I am a greenwee')
+
+	var styles = e('style', {
+		'#comp': {
+			color: 'blue'
+		},
+		'.greeter':{
+			color: 'green'
+		}
+	})
+
+	var main = e('div', [
+		el, b, styles
+	])
+
+	DOM.render(main)
+
+	</script>
+
+ </html>

--- a/examples/styles.html
+++ b/examples/styles.html
@@ -24,7 +24,8 @@
 			color: 'blue'
 		},
 		'.greeter':{
-			color: 'green'
+			backgroundColor: 'grey',
+			lineHeight: '1px'
 		}
 	})
 

--- a/index.js
+++ b/index.js
@@ -13,5 +13,5 @@ module.exports = {
     create: create,
     VNode: VNode,
     VText: VText,
-    vDOM: vDom
+    vDOM: vDOM
 }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var h = require("./h.js")
 var create = require("./create-element.js")
 var VNode = require('./vnode/vnode.js')
 var VText = require('./vnode/vtext.js')
+var vDOM = require('./vDOM.js')
 
 module.exports = {
     diff: diff,
@@ -11,5 +12,6 @@ module.exports = {
     h: h,
     create: create,
     VNode: VNode,
-    VText: VText
+    VText: VText,
+    vDOM: vDom
 }

--- a/vDOM.js
+++ b/vDOM.js
@@ -24,3 +24,5 @@ function vDOM(){
   };
     
 }
+
+module.exports = vDOM;

--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -45,7 +45,7 @@ function h(tagName, properties, children) {
     // parse styles
     if (tag == 'STYLE' && properties){
         childNodes = parseStyles(properties);
-        properties = null
+        props = null
     }
 
     // fix cursor bug

--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -14,6 +14,8 @@ var parseTag = require('./parse-tag.js');
 var softSetHook = require('./hooks/soft-set-hook.js');
 var evHook = require('./hooks/ev-hook.js');
 
+var parseStyles = require('./parse-styles');
+
 module.exports = h;
 
 function h(tagName, properties, children) {
@@ -38,6 +40,12 @@ function h(tagName, properties, children) {
     if (props.hasOwnProperty('namespace')) {
         namespace = props.namespace;
         props.namespace = undefined;
+    }
+
+    // parse styles
+    if (tag == 'STYLE' && properties){
+        childNodes = parseStyles(properties);
+        properties = null
     }
 
     // fix cursor bug

--- a/virtual-hyperscript/parse-styles.js
+++ b/virtual-hyperscript/parse-styles.js
@@ -9,9 +9,11 @@ function parseStyles(properties){
 	var content = JSON.stringify(props)
 	content = content
 		.substring(1,content.length -1)
+		.replace(/\"\,\"/g,'";"')
 		.replace(/\'|\"/g,'')
 		.replace(/\:\{/g,'{')
 		.replace(/\}\,/g,'}')
+		.replace(/([a-z\d])([A-Z])/g,'$1-$2').toLowerCase()
 
 	return [new VText(content)];
 }

--- a/virtual-hyperscript/parse-styles.js
+++ b/virtual-hyperscript/parse-styles.js
@@ -1,0 +1,17 @@
+var VText = require('../vnode/vtext.js');
+
+module.exports = parseStyles;
+
+function parseStyles(properties){
+	
+	var props = properties || []
+
+	var content = JSON.stringify(props)
+	content = content
+		.substring(1,content.length -1)
+		.replace(/\'|\"/g,'')
+		.replace(/\:\{/g,'{')
+		.replace(/\}\,/g,'}')
+
+	return [new VText(content)];
+}

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -176,3 +176,24 @@ test("h with two ids", function (assert) {
 
     assert.end()
 })
+
+test("h with style", function (assert) {
+    var node = h("style", {
+        "#foo": {color: 'blue'},
+        ".bar": {height: '10px', width: '15px'}
+    })
+
+    assert.equal(node.children[0].text,
+        "#foo{color:blue}.bar{height:10px;width:15px}")
+    assert.equal(Object.keys(node.properties).length, 0)
+
+    assert.end()
+})
+
+test("h with style using camelCasing", function (assert) {
+    var node = h("style", { "#foo": {"lineHeight":"2em"} })
+
+    assert.equal(node.children[0].text, "#foo{line-height:2em}")
+
+    assert.end()
+})


### PR DESCRIPTION
vDOM is just a bootstrap object to initialize a virtual dom, and to provide a render method to update the virtual dom. This is entirely for convenience for using the virtual dom out-the-box without setup. This is just for browser use, as it requires the document object.

```
// example when virtual-dom is imported via script tag
var vDOM = new virtualDOM.vDOM()
vDOM.render(vTree)
```

The styles h tag renders a vNode with 'STYLE' tag and a child vText node with the text content of parsed styles.

```
h('style', {  '#foo':{color:'blue',weight:500}  })
```
Will render to a vText child with text:
```
#foo{color:blue;weight:500}
```
camelCasing is also available:
```
h('style', { '.bar':{backgroundColor:'grey'} })
// .bar{background-color:grey}
``` 

This is useful if a stylesheet is needed to be built dynamically within javascript. General classes, animations, css events (ie hover), even media queries can be declared using this tag.