### PR TITLE
Update docs for style setting

### DIFF
--- a/docs/vnode.md
+++ b/docs/vnode.md
@@ -32,7 +32,7 @@ Hook.prototype.hook = function(elem, key, previousValue) {
 }
 
 var tagName = "div"
-var style = "width: 100px; height: 100px; background-color: #FF0000;"
+var style = { width: "100px", height: "100px", "background-color": "#FF0000" }
 var attributes = {"class": "red box", style: style }
 var key = "my-unique-red-box"
 var namespace = "http://www.w3.org/1999/xhtml"


### PR DESCRIPTION
Safari 9.1 exposed a problem where the way I was setting style (like the previous string in the doc here) was trying to write to the style attribute which was an instance of CSSStyleDeclaration, throwing an error that I was setting something readonly.

https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration
