### PR TITLE
Add support for Iterable children parameters to h()

### DIFF
--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -13,6 +13,8 @@ var isVThunk = require('../vnode/is-thunk');
 var parseTag = require('./parse-tag.js');
 var softSetHook = require('./hooks/soft-set-hook.js');
 var evHook = require('./hooks/ev-hook.js');
+var isIterable = require('./iterable.js').isIterable;
+var getIterator = require('./iterable.js').getIterator;
 
 module.exports = h;
 
@@ -81,6 +83,13 @@ function addChild(c, childNodes, tag, props) {
         for (var i = 0; i < c.length; i++) {
             addChild(c[i], childNodes, tag, props);
         }
+    } else if (isIterable(c)) {
+        var iterator = getIterator(c);
+        var result = iterator.next();
+        while (! result.done) {
+            addChild(result.value, childNodes, tag, props);
+            result = iterator.next();
+        }
     } else if (c === null || c === undefined) {
         return;
     } else {
@@ -116,7 +125,7 @@ function isChild(x) {
 }
 
 function isChildren(x) {
-    return typeof x === 'string' || isArray(x) || isChild(x);
+    return typeof x === 'string' || isArray(x) || isIterable(x) || isChild(x);
 }
 
 function UnexpectedVirtualElement(data) {

--- a/virtual-hyperscript/iterable.js
+++ b/virtual-hyperscript/iterable.js
@@ -1,0 +1,19 @@
+var window = require('global/window');
+
+var ES2015_SYMBOL_ITERATOR = window.Symbol && window.Symbol.iterator;
+var LEGACY_SYMBOL_ITERATOR = '@@iterator';
+var SYMBOL_ITERATOR = ES2015_SYMBOL_ITERATOR || LEGACY_SYMBOL_ITERATOR;
+
+function getIterator(x) {
+    return x && x[SYMBOL_ITERATOR];
+}
+
+function isIterable(x) {
+    return !! getIterator(x);
+}
+
+module.exports = {
+    SYMBOL_ITERATOR: SYMBOL_ITERATOR,
+    getIterator: getIterator,
+    isIterable: isIterable
+}

--- a/virtual-hyperscript/test/create-iterator.js
+++ b/virtual-hyperscript/test/create-iterator.js
@@ -1,0 +1,23 @@
+var SYMBOL_ITERATOR = require("../iterable").SYMBOL_ITERATOR
+
+function createIterator(array) {
+    var it = {}
+    it[SYMBOL_ITERATOR] = {
+        next: function() {
+            if (array.length > 0) {
+                var first = array.shift()
+                return {
+                    value: first,
+                    done: false
+                }
+            } else {
+                return {
+                    done: true
+                }
+            }
+        }
+    }
+    return it
+}
+
+module.exports = createIterator

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -2,6 +2,7 @@ var test = require("tape")
 var EvStore = require('ev-store')
 
 var h = require("../index")
+var createIterator = require("./create-iterator")
 
 test("h is a function", function (assert) {
     assert.equal(typeof h, "function")
@@ -97,6 +98,15 @@ test("h with child", function (assert) {
 
 test("h with children", function (assert) {
     var node = h("div", [h("span")])
+
+    assert.equal(node.children[0].tagName, "SPAN")
+
+    assert.end()
+})
+
+test("h with children iterator", function (assert) {
+    var iterator = createIterator([h("span")])
+    var node = h("div", iterator)
 
     assert.equal(node.children[0].tagName, "SPAN")
 


### PR DESCRIPTION
Fixes https://github.com/Matt-Esch/virtual-dom/issues/276

The issue of generic support for Iterables in all JS libraries was [raised on Twitter](https://twitter.com/leeb/status/746733697093668864) by @leebyron and it would make it really nice to work with Immutable (among others).

Yes, it does rely on ES2015 primitives but it should fall back gracefully if used in another context.

This tentative submission adds support for Iterable lists for the `children` argument of `h` (easier than the `attributes` which require a map).

Feedback very much welcome on this!

PS: Hey @OliverJAsh :wave: 
