### PR TITLE
Added toLowerCase for vnode.tagName to support webcomponents

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -283,7 +283,7 @@ test("injected document object is used", function (assert) {
     var count = 0
     var doc = {
         createElement: function createElement(tagName) {
-            assert.equal(tagName, "DIV")
+            assert.equal(tagName, "div")
             count++
             return { tagName: "DIV", appendChild: function (t) {
                 assert.equal(t, "hello")

--- a/vdom/create-element.js
+++ b/vdom/create-element.js
@@ -27,8 +27,8 @@ function createElement(vnode, opts) {
     }
 
     var node = (vnode.namespace === null) ?
-        doc.createElement(vnode.tagName) :
-        doc.createElementNS(vnode.namespace, vnode.tagName)
+        doc.createElement(vnode.tagName.toLowerCase()) :
+        doc.createElementNS(vnode.namespace, vnode.tagName.toLowerCase())
 
     var props = vnode.properties
     applyProperties(node, props)


### PR DESCRIPTION
I actually think this could be a bug in Chrome's implementation of Custom Elements, but I thought I'd open a PR to at least open a discussion on it. If it is indeed a Chrome issue, then of course I don't expect this to be merged &mdash; however I couldn't find a related Chrome bug.

**The issue:**

Whilst in most cases HTML is case insensitive, using [Custom Elements v1's](https://www.w3.org/TR/custom-elements/) `customElements.define` it seems that custom elements are case-sensitive when using `document.createElement` as shown [in the following Fiddle](https://jsfiddle.net/emdnz2jo/) (**note:** requires Chrome Canary, as `customElements.define` won't work in Chrome yet).

By adding `toLowerCase` in `virtual-dom`'s `vnode.tagName` the `connectedCallback` function is invoked as expected. Interestingly, in the Fiddle it doesn't matter how the HTML is written (rightfully so), as both `<example-node />` and `<EXAMPLE-NODE />` are equals, and thus work perfectly.

Thoughts?
