### PR TITLE
Fixed IE issue

### DIFF
--- a/vdom/patch-op.js
+++ b/vdom/patch-op.js
@@ -62,7 +62,7 @@ function insertNode(parentNode, vNode, renderOptions) {
 function stringPatch(domNode, leftVNode, vText, renderOptions) {
     var newNode
 
-    if (domNode.nodeType === 3) {
+    if (domNode.nodeType === 3 && domNode.parentNode !== null) {
         domNode.replaceData(0, domNode.length, vText.text)
         newNode = domNode
     } else {


### PR DESCRIPTION
Fixes an IE 'Invalid Argument' exception with textareas:
Error happens, because (for whatever reason) IE temporarily converts <textarea placeholder="foo"></textarea> to <textarea placeholder="foo">foo</textarea>. This triggers a diff patch on the 'foo' innerHTML as a VTEXT node, but by the time vdom tries to set the VTEXT's value, it has been orphaned by IE.

IE throws an error whenever you try to set the nodeValue of a parentless node which exposes itself as an 'Invalid Argument' exception.