### PR TITLE
fix: add number verification for children

### DIFF
--- a/virtual-hyperscript/index.js
+++ b/virtual-hyperscript/index.js
@@ -116,7 +116,7 @@ function isChild(x) {
 }
 
 function isChildren(x) {
-    return typeof x === 'string' || isArray(x) || isChild(x);
+    return typeof x === 'string' || typeof x === 'number' || isArray(x) || isChild(x);
 }
 
 function UnexpectedVirtualElement(data) {

--- a/virtual-hyperscript/test/h.js
+++ b/virtual-hyperscript/test/h.js
@@ -188,3 +188,13 @@ test("h with two ids", function (assert) {
 
     assert.end()
 })
+
+test("h with Number", function (assert) {
+    var node = h("div", 1)
+    var node2 = h("div", [1])
+
+    assert.equal(node.children[0].text, "1")
+    assert.equal(node2.children[0].text, "1")
+
+    assert.end()
+})


### PR DESCRIPTION
e.g.

```js
import { h, create } from 'virtual-dom'

const vtree = h('div', [
  h('p', 1),  // the children is number
  h('p', [1]),  // the children is an array that contains number
])

const $rootNode = create(vtree)
document.body.appendChild($rootNode)

`
  <div>
    <p></p>  // not text '1'
    <p>1</p>
  </div>
`
```

OMG, why not render the first `p`'s text '1'?

next, see the source code:

```js
function h(tagName, properties, children) {
  var childNodes = [];
  var tag, props, key, namespace;
   
  // children verifycation
  if (!children && isChildren(properties)) {  
    children = properties;
    props = {};
  }
    
  // ...
  
  // add childs
  if (children !== undefined && children !== null) {
    addChild(children, childNodes, tag, props);
  }

  return new VNode(tag, props, childNodes, key, namespace);
}

function isChild(x) {
  return isVNode(x) || isVText(x) || isWidget(x) || isVThunk(x);
}

function isChildren(x) {
  // not number verifycation
  return typeof x === 'string' || isArray(x) || isChild(x);
}

function addChild(c, childNodes, tag, props) {
  if (typeof c === 'string') {
    childNodes.push(new VText(c));
  } else if (typeof c === 'number') {  // turns number into VText
    childNodes.push(new VText(String(c)));
  } else if (isChild(c)) {
    childNodes.push(c);
  } else if (isArray(c)) {
    for (var i = 0; i < c.length; i++) {
        addChild(c[i], childNodes, tag, props);  // recursion array's value
    }
  } // ...
}
```

I think the `h('p', 1)` and `h('p', [1])` must be the same representation:

- the children is number
- the children is an array that contains number
