### PR TITLE
update next-tick to next-tick-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ev-store": "^7.0.0",
     "global": "^4.3.0",
     "is-object": "^1.0.1",
-    "next-tick": "^0.2.2",
+    "next-tick-2": "^1.1.0",
     "x-is-array": "0.1.0",
     "x-is-string": "0.1.0"
   },

--- a/virtual-hyperscript/hooks/focus-hook.js
+++ b/virtual-hyperscript/hooks/focus-hook.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var document = require("global/document");
-var nextTick = require("next-tick");
+var nextTick = require("next-tick-2");
 
 module.exports = MutableFocusHook;
 


### PR DESCRIPTION
`next-tick-2` does not inject the node `process` module into browserified output, resulting in smaller javascript bundles.