### PR TITLE
throw better exception when duplicate keys are found

### DIFF
--- a/test/keys.js
+++ b/test/keys.js
@@ -655,6 +655,17 @@ test('mixed keys move from i>0 to i<length-1', function (assert) {
     assert.end()
 })
 
+test('duplicate keys throws appropriate error', function (assert) {
+    var start = nodesFromArray(['1', '2', '3'])
+    var end = nodesFromArray(['1', '2', '2', '3'])
+
+    assert.throws(function () {
+      diff(start, end)
+    }, 'duplicate vdom key')
+
+    assert.end()
+})
+
 /*
 keyTest(
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42],

--- a/test/main.js
+++ b/test/main.js
@@ -9,6 +9,7 @@ var TextNode = require("../vnode/vtext")
 var version = require("../vnode/version")
 var assertEqualDom = require("./lib/assert-equal-dom.js")
 var patchCount = require("./lib/patch-count.js")
+var selector = require("../vnode/selector")
 
 
 
@@ -1024,6 +1025,12 @@ test("Different namespaces creates a patch", function (assert) {
     assert.equal(rootNode.tagName, "div")
     assert.equal(rootNode.namespaceURI, "undefined")
 
+    assert.end()
+})
+
+test('can pretty print node as selector', function (assert) {
+    var node = h("div", {id: 'an-id', className: " class-1  class-2"})
+    assert.equal(selector(node), "div#an-id.class-1.class-2")
     assert.end()
 })
 

--- a/vnode/selector.js
+++ b/vnode/selector.js
@@ -1,0 +1,5 @@
+module.exports = function selector (node) {
+    return node.tagName.toLowerCase()
+        + (node.properties.id ? '#' + node.properties.id : '')
+        + (node.properties.className ? '.' + node.properties.className.trim().replace(/ +/g, '.') : '')
+}

--- a/vtree/diff.js
+++ b/vtree/diff.js
@@ -6,6 +6,7 @@ var isVText = require("../vnode/is-vtext")
 var isWidget = require("../vnode/is-widget")
 var isThunk = require("../vnode/is-thunk")
 var handleThunk = require("../vnode/handle-thunk")
+var selector = require("../vnode/selector")
 
 var diffProps = require("./diff-props")
 
@@ -400,7 +401,11 @@ function keyIndex(children) {
         var child = children[i]
 
         if (child.key) {
-            keys[child.key] = i
+            if (keys[child.key]) {
+                throw new Error('duplicate vdom key: ' + child.key + ', vdom: ' + selector(child))
+            } else {
+                keys[child.key] = i
+            }
         } else {
             free.push(i)
         }


### PR DESCRIPTION
If VDOM has duplicate keys we see this error, which doesn't explain what went wrong:

```
Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'
```

This patch detects duplicate keys and throws this error instead:

```
duplicate vdom key: <key>, vdom: <vdom-selector>
```

Where `key` is the duplicate key, and `vdom-selector` is a `tag#id.class` representation of the node so you can find it.