### PR TITLE
Fix bug causing style comparisons to be skipped

### DIFF
--- a/test/lib/assert-equal-dom.js
+++ b/test/lib/assert-equal-dom.js
@@ -62,6 +62,7 @@ function equalStyle(a, b) {
     keys.sort()
 
     for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
         if (a[key] !== b[key]) {
             return false
         }

--- a/test/lib/assert-equal-dom.js
+++ b/test/lib/assert-equal-dom.js
@@ -62,7 +62,7 @@ function equalStyle(a, b) {
     keys.sort()
 
     for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
+        var key = keys[i]
         if (a[key] !== b[key]) {
             return false
         }


### PR DESCRIPTION
You seem to test the same equality {keys.length} times rather than testing equality for each key.