### PR TITLE
vtree/diff: combine unhook and destroyWidget to use a single walk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
+- 'node'
+- 'lts/*'
 before_install:
 - npm install npm -g
 before_script:


### PR DESCRIPTION
I was reading this over the weekend and came across the following `TODO` in clearState, which seemed like a worthwhile thing to address.

    // TODO: Make this a single walk, not two
    unhook(vNode, patch, index)
    destroyWidgets(vNode, patch, index)

However, I have no context on whether this change will result in a measurable performance improvement. I'm happy to add benchmarks, if necessary.