### PR TITLE
.travis.yml: use 'node' and 'lts/*' to fix build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
+- 'node'
+- 'lts/*'
 before_install:
 - npm install npm -g
 before_script:


### PR DESCRIPTION
On master, travis fails currently with the following error:

    ERROR: npm is known not to run on Node.js v0.12.18
    You'll need to upgrade to a newer version in order to use this
    version of npm. Supported versions are 4, 6, 7, 8, 9. You can find the
    latest version at https://nodejs.org/

This updates .travis.yml to use the latest stable node ('node')
and all the latest LTS releases ('lts/*'). The relevant docs are at
https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions