### PR TITLE
getReorderPatch support patch of array

### DIFF
--- a/test/keys.js
+++ b/test/keys.js
@@ -792,7 +792,12 @@ function getReorderPatch(patches) {
     for (var key in patches) {
         if (key !== "a" && patches.hasOwnProperty(key)) {
             var patch = patches[key]
-            if (patch.type === VPatch.ORDER) {
+            if (Array.isArray(patch)) {
+              var orderPathes = patch.filter(p => p.type === VPatch.ORDER)
+              if (orderPathes.length >= 1) {
+                return orderPathes[0]
+              }
+            } else if (patch.type === VPatch.ORDER) {
                 return patch
             }
         }


### PR DESCRIPTION
When I change the 'keys' test case as follows, the 'getReorderPatch' function doesn't work, because the patch returned from 'diff' is an Array.

```javascript
test("keys get reordered", function (assert) {
    var leftNode = h("div", [
        h("div"),
        h("div", { key: 1 }),
        h("div"),
        h("div", { key: 2 }),
    ])
    var rightNode = h("div", [
        h("div", { key: 1 }),
        h("div"),
        h("div", { key: 3 }),
        h("div"),
    ]);
    var rootNode = render(leftNode)

    var patches = diff(leftNode, rightNode)
    assert.equal(patchCount(patches), 2)
    assertReorderEquals(assert, patches, {
        removes: [
            {from: 1, key: '1' },
            {from: 2, key: null },
            {from: 2, key: '3' },
        ],
        inserts: [
            {to: 0, key: '1' },
            {to: 2, key: '3' },
        ]
    })
})
```