### PR TITLE
Virtual-dom: Removed PhantomJS dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
+- '8'
+- '9'
 before_install:
 - npm install npm -g
 before_script:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "istanbul": "^0.3.13",
     "min-document": "^2.14.0",
     "opn": "^1.0.1",
-    "run-browser": "^2.0.2",
     "tap-dot": "^1.0.0",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0",


### PR DESCRIPTION
Phantomjs is an unmaintained project. Removed phantomjs dependency from package.json.
run-browser supports phantomjs hence removed it from devdependency.

Signed-off-by: ossdev07 <ossdev@puresoftware.com>